### PR TITLE
[IOPLT-518] Remove `$ref` from openapi responses

### DIFF
--- a/.changeset/forty-kiwis-teach.md
+++ b/.changeset/forty-kiwis-teach.md
@@ -2,4 +2,6 @@
 "functions-subscription": patch
 ---
 
-Replace all $ref: '#/components/responses/... references with definitions and define some properties as required
+- Replace all $ref: '#/components/responses/... references with definitions.
+- Define some properties as required.
+- Add `409` and `202` responses.

--- a/.changeset/forty-kiwis-teach.md
+++ b/.changeset/forty-kiwis-teach.md
@@ -2,6 +2,6 @@
 "functions-subscription": patch
 ---
 
-- Replace all $ref: '#/components/responses/... references with definitions.
+- Replace all `$ref: '#/components/responses/...'` references with definitions.
 - Define some properties as required.
 - Add `409` and `202` responses.

--- a/.changeset/forty-kiwis-teach.md
+++ b/.changeset/forty-kiwis-teach.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": patch
+---
+
+Replace all $ref: '#/components/responses/... references with definitions and define some properties as required

--- a/apps/functions-subscription/api/internal.yaml
+++ b/apps/functions-subscription/api/internal.yaml
@@ -14,11 +14,19 @@ paths:
       operationId: info
       responses:
         '200':
-          $ref: '#/components/responses/200Info'
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationInfo'
         '404':
-          $ref: '#/components/responses/404NotFound'
+          description: Not Found
         '500':
-          $ref: '#/components/responses/500InternalServerError'
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
   /trials/{trialId}/subscriptions/{userId}:
     get:
       operationId: getSubscription
@@ -31,13 +39,21 @@ paths:
         - $ref: '#/components/parameters/pathUserId'
       responses:
         '200':
-          $ref: '#/components/responses/200Subscription'
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
         '401':
-          $ref: '#/components/responses/401Unauthorized'
+          description: Unauthorized
         '404':
-          $ref: '#/components/responses/404NotFound'
+          description: Not Found
         '500':
-          $ref: '#/components/responses/500InternalServerError'
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
   /trials/{trialId}/subscriptions:
     post:
       operationId: createSubscription
@@ -52,15 +68,27 @@ paths:
               $ref: '#/components/schemas/CreateSubscription'
       responses:
         '201':
-          $ref: '#/components/responses/201Subscription'
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
         '400':
-          $ref: '#/components/responses/400BadRequest'
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
         '401':
-          $ref: '#/components/responses/401Unauthorized'
+          description: Unauthorized
         '404':
-          $ref: '#/components/responses/404NotFound'
+          description: Not Found
         '500':
-          $ref: '#/components/responses/500InternalServerError'
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
 
 components:
   securitySchemes:
@@ -139,34 +167,3 @@ components:
           $ref: '#/components/schemas/CreatedAt'
         updatedAt:
           $ref: '#/components/schemas/UpdatedAt'
-  responses:
-    500InternalServerError:
-      description: Internal Server Error
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ProblemJson'
-    400BadRequest:
-      description: Bad Request.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ProblemJson'
-    401Unauthorized:
-      description: Unauthorized
-    404NotFound:
-      description: Not Found
-    200Info:
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ApplicationInfo'
-    200Subscription:
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Subscription'
-    201Subscription:
-      $ref: '#/components/responses/200Subscription'

--- a/apps/functions-subscription/api/internal.yaml
+++ b/apps/functions-subscription/api/internal.yaml
@@ -151,11 +151,19 @@ components:
       minLength: 1
     CreateSubscription:
       type: object
+      required:
+        - userId
       properties:
         userId:
           $ref: '#/components/schemas/UserId'
     Subscription:
       type: object
+      required:
+        - trialId
+        - userId
+        - state
+        - createdAt
+        - updatedAt
       properties:
         trialId:
           $ref: '#/components/schemas/TrialId'

--- a/apps/functions-subscription/api/internal.yaml
+++ b/apps/functions-subscription/api/internal.yaml
@@ -73,6 +73,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Subscription'
+        '202':
+          description: Accepted
         '400':
           description: Bad Request.
           content:
@@ -83,6 +85,8 @@ paths:
           description: Unauthorized
         '404':
           description: Not Found
+        '409':
+          description: Conflict
         '500':
           description: Internal Server Error
           content:


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Replace all `$ref: '#/components/responses/...` with definitions
- Define some properties as required
- Add `409` and `202` responses

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before this change, the `gen-api-models` tool generated all the `$ref: '#/components/responses/...` references without a response type (e.g., `r.IResponseType<500, undefined, never>`) instead of generating them with the correct returned response (e.g., `r.IResponseType<500, ProblemJson, never>`).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally, running `gen-api-models` with `--request-types --response-decoders --client` options

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
