### PR TITLE
[IOPLT-567] Add state property to create subscription endpoint

### DIFF
--- a/apps/functions-subscription/api/internal.yaml
+++ b/apps/functions-subscription/api/internal.yaml
@@ -184,17 +184,34 @@ components:
         - SUBSCRIBED
         - ACTIVE
         - DISABLED
+    CreateSubscriptionState:
+      type: string
+      description: |-
+        - SUBSCRIBED: The user is subscribed to the specified trial and does
+            not have any access to the specified trial. The system is going to
+            activate the user if any slot for the trial is available.
+        - ACTIVE: The user has the access to the specified trial.
+      enum:
+        - SUBSCRIBED
+        - ACTIVE
     TrialId:
       type: string
       description: Unique identifier of the trial.
       minLength: 1
     CreateSubscription:
+      description: >
+        Payload to create a subscription.
+        If the `state` property is not provided, the subscription will have the
+        `SUBSCRIBED` state. Otherwise, the subscription will be created with the
+        provided state.
       type: object
       required:
         - userId
       properties:
         userId:
           $ref: '#/components/schemas/UserId'
+        state:
+          $ref: '#/components/schemas/CreateSubscriptionState'
     Subscription:
       type: object
       required:


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Update the `/trials/{trialId}/subscriptions` to accept a state (not required) when creating a subscription.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to create an active subscription for a user.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Check the output on https://editor.swagger.io/?url=https://raw.githubusercontent.com/pagopa/trial-system/features/users-activation-openapi/apps/functions-subscription/api/internal.yaml

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
