### PR TITLE
[IOPLT-576] Fix number of activation requests activated by the activation job

### DIFF
--- a/.changeset/loud-insects-hug.md
+++ b/.changeset/loud-insects-hug.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": patch
+---
+
+[IOPLT-576] Fetch proper number of activation requests when processing an activation job

--- a/apps/functions-subscription/src/use-cases/process-activation-job.ts
+++ b/apps/functions-subscription/src/use-cases/process-activation-job.ts
@@ -12,16 +12,15 @@ export const processActivationJob = (
 ) =>
   pipe(
     RTE.ask<Env>(),
-    RTE.flatMapTaskEither(({ activationRequestRepository }) => {
-      const itemsToFetch = Math.min(
-        maxFetchSize,
-        job.usersToActivate - job.usersActivated,
-      );
-      return pipe(
-        activationRequestRepository.list(job.trialId, itemsToFetch),
+    RTE.let('limit', () =>
+      Math.min(maxFetchSize, job.usersToActivate - job.usersActivated),
+    ),
+    RTE.flatMapTaskEither(({ activationRequestRepository, limit }) =>
+      pipe(
+        activationRequestRepository.list(job.trialId, limit),
         TE.flatMap((activationRequests) =>
           activationRequestRepository.activate(job, activationRequests),
         ),
-      );
-    }),
+      ),
+    ),
   );

--- a/apps/functions-subscription/src/use-cases/process-activation-job.ts
+++ b/apps/functions-subscription/src/use-cases/process-activation-job.ts
@@ -12,12 +12,16 @@ export const processActivationJob = (
 ) =>
   pipe(
     RTE.ask<Env>(),
-    RTE.flatMapTaskEither(({ activationRequestRepository }) =>
-      pipe(
-        activationRequestRepository.list(job.trialId, maxFetchSize),
+    RTE.flatMapTaskEither(({ activationRequestRepository }) => {
+      const itemsToFetch = Math.min(
+        maxFetchSize,
+        job.usersToActivate - job.usersActivated,
+      );
+      return pipe(
+        activationRequestRepository.list(job.trialId, itemsToFetch),
         TE.flatMap((activationRequests) =>
           activationRequestRepository.activate(job, activationRequests),
         ),
-      ),
-    ),
+      );
+    }),
   );


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->
When processing any changes of an activation job, the number of activation requests to process is the one defined by the job itself.
The system has a limit on the query that fetches the number of activation requests; if the number provided by the job is less than that limit, then the consumer should activate only the number of users defined within the job.

#### List of Changes
<!--- Describe your changes in detail -->
- Add unit test to cover the case that causes the bug
- Fix logic that decide the number of elements to fetch during the activation

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to make sure we only activate the users defined in the activation job

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
