### PR TITLE
Remove `enable_partitioning` property from servicebus topic

### DIFF
--- a/infra/resources/modules/commons/servicebus.tf
+++ b/infra/resources/modules/commons/servicebus.tf
@@ -22,6 +22,5 @@ resource "azurerm_servicebus_topic" "events" {
   name         = "${local.domain}-topic-events"
   namespace_id = azurerm_servicebus_namespace.main.id
 
-  enable_partitioning = true
-  support_ordering    = true
+  support_ordering = true
 }


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Remove `enable_partitioning` property from servicebus topic

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Topics created in a Premium namespace are partitioned according to the partition configuration of the namespace. If the parameter `enable_partitioning` of a topic is set to true, each time terraform apply is executed, the resource will be replaced because Terraform tries to set `enable_partitioning` from false to true, and enable_partitioning forces a new creation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
N/A

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
