### PR TITLE
[IOPLT-601] - Activate only subscription in the subscribed state

### DIFF
--- a/.changeset/brown-books-divide.md
+++ b/.changeset/brown-books-divide.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": patch
+---
+
+[IOPLT-601] - Activate only subscriptions that are in the subscribed state

--- a/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
@@ -26,7 +26,7 @@ describe('processActivationRequest', () => {
     expect(mockEnv.subscriptionHistoryWriter.insert).toBeCalledTimes(0);
   });
 
-  it('should return insert a new version if the latest one is not SUBSCRIBED', async () => {
+  it('should not insert a new version if the latest subscription-history is not SUBSCRIBED', async () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 

--- a/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
@@ -26,7 +26,25 @@ describe('processActivationRequest', () => {
     expect(mockEnv.subscriptionHistoryWriter.insert).toBeCalledTimes(0);
   });
 
-  it('should create a new version of subscription-history if activated', async () => {
+  it('should return insert a new version if the latest one is not SUBSCRIBED', async () => {
+    const mockEnv = makeTestEnv();
+    const testEnv = mockEnv as unknown as Capabilities;
+
+    mockEnv.hashFn
+      .mockReturnValueOnce({ value: aSubscriptionHistoryV1.subscriptionId })
+    mockEnv.subscriptionHistoryReader.getLatest.mockReturnValueOnce(
+      TE.right(O.some(aSubscriptionHistoryV1)),
+    );
+
+    const actual =
+      await processActivationRequest(anActivationRequestActivated)(testEnv)();
+
+    expect(actual).toStrictEqual(E.right(O.some(aSubscriptionHistoryV1)));
+    expect(mockEnv.subscriptionHistoryReader.getLatest).toBeCalledTimes(1);
+    expect(mockEnv.subscriptionHistoryWriter.insert).toBeCalledTimes(0);
+  });
+
+  it('should create a new version of subscription-history if activated and the latest version is SUBSCRIBED', async () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 

--- a/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
@@ -30,14 +30,16 @@ describe('processActivationRequest', () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 
-    mockEnv.hashFn
-      .mockReturnValueOnce({ value: aSubscriptionHistoryV1.subscriptionId })
+    mockEnv.hashFn.mockReturnValueOnce({
+      value: aSubscriptionHistoryV1.subscriptionId,
+    });
     mockEnv.subscriptionHistoryReader.getLatest.mockReturnValueOnce(
       TE.right(O.some(aSubscriptionHistoryV1)),
     );
 
-    const actual =
-      await processActivationRequest(anActivationRequestActivated)(testEnv)();
+    const actual = await processActivationRequest(anActivationRequestActivated)(
+      testEnv,
+    )();
 
     expect(actual).toStrictEqual(E.right(O.some(aSubscriptionHistoryV1)));
     expect(mockEnv.subscriptionHistoryReader.getLatest).toBeCalledTimes(1);


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Update `processActivatedRequest` so that only subscription in the subscribed state are activated

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Subscribing a user in an active state causes there to be two versions of the subscription without any update.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
