### PR TITLE
[IOPLT-602] Topic subscription filters event based on `trialId`

### DIFF
--- a/.changeset/large-horses-enjoy.md
+++ b/.changeset/large-horses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": patch
+---
+
+Topic subscription only filter messages with their `trialId` parameter

--- a/apps/functions-subscription/src/adapters/azure/servicebus/__tests__/channel.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/servicebus/__tests__/channel.test.ts
@@ -46,14 +46,14 @@ describe('makeChannelAdminServiceBus', () => {
     );
 
     serviceBusManagementClient.subscriptions.createOrUpdate.mockResolvedValueOnce(
-      {
-        id: 'aSubscriptionId',
-      },
+      {},
     );
 
-    authorizationManagementClient.roleAssignments.create.mockResolvedValueOnce({
-      id: 'anId',
-    });
+    serviceBusManagementClient.rules.createOrUpdate.mockResolvedValueOnce({});
+
+    authorizationManagementClient.roleAssignments.create.mockResolvedValueOnce(
+      {},
+    );
 
     const actual = await makeChannelAdminServiceBus(
       {
@@ -93,6 +93,24 @@ describe('makeChannelAdminServiceBus', () => {
       config.servicebus.names.event,
       trialId,
       { forwardTo: queueResponse.name },
+    );
+
+    expect(
+      serviceBusManagementClient.rules.createOrUpdate,
+    ).toHaveBeenCalledWith(
+      config.servicebus.resourceGroup,
+      config.servicebus.namespace,
+      config.servicebus.names.event,
+      trialId,
+      'FilterByTrialId',
+      {
+        filterType: 'CorrelationFilter',
+        correlationFilter: {
+          properties: {
+            trialId,
+          },
+        },
+      },
     );
 
     expect(

--- a/apps/functions-subscription/src/adapters/azure/servicebus/__tests__/event.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/servicebus/__tests__/event.test.ts
@@ -22,6 +22,9 @@ describe('makeEventWriterServiceBus', () => {
         ...aSubscription,
         state: SubscriptionStateEnum.SUBSCRIBED,
       }),
+      applicationProperties: {
+        trialId: aSubscription.trialId,
+      },
     });
   });
 

--- a/apps/functions-subscription/src/adapters/azure/servicebus/event.ts
+++ b/apps/functions-subscription/src/adapters/azure/servicebus/event.ts
@@ -13,6 +13,14 @@ export const makeEventWriterServiceBus = (
     // explicitly use SubscriptionEvent encoder, which is the one
     // used by the consumer to decode events
     const body = SubscriptionEvent.encode({ ...event, state });
-    return TE.tryCatch(() => client.sendMessages({ body }), E.toError);
+    const { trialId } = body;
+    return TE.tryCatch(
+      () =>
+        client.sendMessages({
+          body,
+          applicationProperties: { trialId },
+        }),
+      E.toError,
+    );
   },
 });


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

Depends on #109
> [!NOTE]
> Since filters can't evaluate body's parameters, we need to add a custom property.
> [Take a look at the Azure documentation here](https://learn.microsoft.com/en-us/azure/service-bus-messaging/topic-filters?WT.mc_id=Portal-Microsoft_Azure_ServiceBus#:~:text=All%20filters%20evaluate%20message%20properties.%20Filters%20can%27t%20evaluate%20the%20message%20body.).

#### List of Changes
<!--- Describe your changes in detail -->
- The `send` method of the `EventWriter` now add a new custom application property `trialId`
- Add a rule on Topic Subscriptions to only get events of a single TrialId

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need the topic subscription consumes only the events related to a single trial.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
