### PR TITLE
[IOPLT-609] Create activation job when creating the trial

### DIFF
--- a/.changeset/odd-radios-tap.md
+++ b/.changeset/odd-radios-tap.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": minor
+---
+
+[IOPLT-609] Create the activation job when creating a trial

--- a/infra/resources/modules/commons/servicebus.tf
+++ b/infra/resources/modules/commons/servicebus.tf
@@ -13,6 +13,7 @@ resource "azurerm_servicebus_namespace" "main" {
   network_rule_set {
     default_action                = "Allow"
     public_network_access_enabled = false
+    trusted_services_allowed      = true
   }
 
   tags = var.tags


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `trusted_services_allowed` to the servicebus configuration
- Create the activation job when processing the trial creations
    - Handle `ItemAlreadyExists` error

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to automate the creation of the activation job when a trial is created

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my code.
- [ ] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
