### PR TITLE
[IOPLT-625] Create replica preferred cosmos client

### DIFF
--- a/.changeset/wild-ties-greet.md
+++ b/.changeset/wild-ties-greet.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": patch
+---
+
+[IOPLT-625] Create another cosmos client with connection policy that redirects reads on `subscription` container to the replicated region


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Centralize the `DefaultAzureCredentials`
- Create another CosmosDB Client
    - This client has the `preferredLocations` option set which define the order of the location where to fetch the data

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To reduce the load on the containers, we want to direct the reads on the replicated region.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
