### PR TITLE
[IOPLT-620] Add check on x-user-groups header

### DIFF
--- a/.changeset/moody-gifts-impress.md
+++ b/.changeset/moody-gifts-impress.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": patch
+---
+
+[IOPLT-620] Add check on x-user-groups header

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/create-trial.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/create-trial.test.ts
@@ -23,7 +23,6 @@ describe('makePostTrialHandler', () => {
     expect(actual.status).toStrictEqual(403);
     expect(await actual.json()).toMatchObject({
       status: 403,
-      detail: 'Missing required groups: ApiTrialManager',
     });
   });
 

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/create-trial.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/create-trial.test.ts
@@ -8,6 +8,25 @@ import { makePostTrialHandler } from '../create-trial';
 import { ItemAlreadyExists } from '../../../../domain/errors';
 
 describe('makePostTrialHandler', () => {
+  it('should return 403 if x-user-groups header does not contain the correct group', async () => {
+    const request = new HttpRequest({
+      url: makeAValidCreateTrialRequest().url,
+      method: makeAValidCreateTrialRequest().method,
+      headers: { 'x-user-groups': 'Guest,AnotherGroup' },
+      body: { string: await makeAValidCreateTrialRequest().text() },
+    });
+    const env = makeTestSystemEnv();
+    const actual = await makePostTrialHandler(env)(
+      request,
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(403);
+    expect(await actual.json()).toMatchObject({
+      status: 403,
+      detail: 'Missing required groups: ApiTrialManager',
+    });
+  });
+
   it('should return 202 with the created trial', async () => {
     const env = makeTestSystemEnv();
     env.createTrial.mockReturnValueOnce(TE.right(aTrial));
@@ -27,6 +46,7 @@ describe('makePostTrialHandler', () => {
     const aRequestWithInvalidBody = new HttpRequest({
       url: 'https://function/trials',
       method: 'POST',
+      headers: { 'x-user-groups': 'ApiTrialManager' },
       body: { string: '{}' },
     });
     const env = makeTestSystemEnv();

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/data.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/data.ts
@@ -45,6 +45,7 @@ export const makeAValidGetActivationJobRequest = () =>
   new HttpRequest({
     url: 'https://function/trials/{trialId}/activation-job',
     method: 'GET',
+    headers: { 'x-user-groups': 'ApiTrialManager' },
     params: {
       trialId: aTrialId,
     },
@@ -54,6 +55,7 @@ export const makeAValidUpdateActivationJobRequest = () =>
   new HttpRequest({
     url: 'https://function/trials/{trialId}/activation-job',
     method: 'PUT',
+    headers: { 'x-user-groups': 'ApiTrialManager' },
     body: {
       string: JSON.stringify({
         usersToActivate: anActivationJob.usersToActivate,
@@ -68,6 +70,7 @@ export const makeAValidCreateTrialRequest = () =>
   new HttpRequest({
     url: 'https://function/trials',
     method: 'POST',
+    headers: { 'x-user-groups': 'ApiTrialManager' },
     body: {
       string: JSON.stringify({
         name: aTrial.name,
@@ -80,6 +83,7 @@ export const makeAValidGetTrialRequest = () =>
   new HttpRequest({
     url: 'https://function/trials/{trialId}',
     method: 'GET',
+    headers: { 'x-user-groups': 'ApiTrialManager' },
     params: {
       trialId: aTrialId,
     },

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-activation-job.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-activation-job.test.ts
@@ -5,8 +5,28 @@ import { makeFunctionContext, makeTestSystemEnv } from './mocks';
 import { makeAValidGetActivationJobRequest } from './data';
 import { anActivationJob } from '../../../../domain/__tests__/data';
 import { makeGetActivationJobHandler } from '../get-activation-job';
+import { HttpRequest } from '@azure/functions';
 
 describe('makeGetActivationJobHandler', () => {
+  it('should return 403 if x-user-groups header does not contain the correct group', async () => {
+    const request = new HttpRequest({
+      url: makeAValidGetActivationJobRequest().url,
+      method: makeAValidGetActivationJobRequest().method,
+      headers: { 'x-user-groups': 'Guest,AnotherGroup' },
+      body: { string: await makeAValidGetActivationJobRequest().text() },
+    });
+    const env = makeTestSystemEnv();
+    const actual = await makeGetActivationJobHandler(env)(
+      request,
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(403);
+    expect(await actual.json()).toMatchObject({
+      status: 403,
+      detail: 'Missing required groups: ApiTrialManager',
+    });
+  });
+
   it('should return 200 when the activation job exists', async () => {
     const env = makeTestSystemEnv();
 

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-activation-job.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-activation-job.test.ts
@@ -23,7 +23,6 @@ describe('makeGetActivationJobHandler', () => {
     expect(actual.status).toStrictEqual(403);
     expect(await actual.json()).toMatchObject({
       status: 403,
-      detail: 'Missing required groups: ApiTrialManager',
     });
   });
 

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-trial.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-trial.test.ts
@@ -5,8 +5,27 @@ import { makeAValidGetTrialRequest } from './data';
 import { makeFunctionContext, makeTestSystemEnv } from './mocks';
 import { makeGetTrialHandler } from '../get-trial';
 import { aTrial } from '../../../../domain/__tests__/data';
+import { HttpRequest } from '@azure/functions';
 
 describe('makeGetTrialHandler', () => {
+  it('should return 403 if x-user-groups header does not contain the correct group', async () => {
+    const request = new HttpRequest({
+      url: makeAValidGetTrialRequest().url,
+      method: makeAValidGetTrialRequest().method,
+      headers: { 'x-user-groups': 'Guest,AnotherGroup' },
+      body: { string: await makeAValidGetTrialRequest().text() },
+    });
+    const env = makeTestSystemEnv();
+    const actual = await makeGetTrialHandler(env)(
+      request,
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(403);
+    expect(await actual.json()).toMatchObject({
+      status: 403,
+      detail: 'Missing required groups: ApiTrialManager',
+    });
+  });
   it('should return 404 when the trial does not exist', async () => {
     const env = makeTestSystemEnv();
 

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-trial.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-trial.test.ts
@@ -23,7 +23,6 @@ describe('makeGetTrialHandler', () => {
     expect(actual.status).toStrictEqual(403);
     expect(await actual.json()).toMatchObject({
       status: 403,
-      detail: 'Missing required groups: ApiTrialManager',
     });
   });
   it('should return 404 when the trial does not exist', async () => {

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/insert-subscription.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/insert-subscription.test.ts
@@ -13,6 +13,25 @@ import { ItemAlreadyExists } from '../../../../domain/errors';
 import { makePostSubscriptionHandler } from '../insert-subscription';
 
 describe('makePostSubscriptionHandler', () => {
+  it('should return 403 if x-user-groups header does not contain the correct group', async () => {
+    const baseRequest =
+      makeAValidCreateSubscriptionRequest(aCreateSubscription);
+    const request = new HttpRequest({
+      url: baseRequest.url,
+      method: baseRequest.method,
+      headers: { 'x-user-groups': 'Guest,AnotherGroup' },
+      body: { string: await baseRequest.text() },
+    });
+    const env = makeTestSystemEnv();
+    const actual = await makePostSubscriptionHandler(env)(
+      request,
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(403);
+    expect(await actual.json()).toMatchObject({
+      status: 403,
+    });
+  });
   it('should return 201 with the created subscription', async () => {
     const env = makeTestSystemEnv();
     env.createSubscription.mockReturnValueOnce(TE.right(aSubscription));

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts';
 import * as E from 'fp-ts/Either';
 import * as H from '@pagopa/handler-kit';
 import { describe, expect, it } from 'vitest';
-import { parseRequestBody } from '../middleware';
+import { parseRequestBody, verifyUserGroup } from '../middleware';
 
 const DummySchema = t.type({
   name: t.string,
@@ -31,5 +31,40 @@ describe('parseRequestBody', () => {
     };
     const actual = parseRequestBody(DummySchema)(req);
     expect(E.isLeft(actual)).toStrictEqual(true);
+  });
+});
+
+describe('verifyUserGroup', () => {
+  it('should return Left if the `x-user-groups` header does not contain the given group', async () => {
+    const req: H.HttpRequest = {
+      ...aValidRequest,
+      headers: {
+        'x-user-groups': 'aGroup,anAnotherGroup',
+      },
+    };
+    const actual = verifyUserGroup('anAdminGroup')(req);
+    const expected = new H.HttpForbiddenError(
+      `Missing required group: anAdminGroup`,
+    );
+    expect(actual).toStrictEqual(E.left(expected));
+  });
+
+  it('should return Right if the `x-user-groups` header is missing', async () => {
+    const req: H.HttpRequest = {
+      ...aValidRequest,
+    };
+    const actual = verifyUserGroup('aGroup')(req);
+    expect(actual).toStrictEqual(E.right(void 0));
+  });
+
+  it('should return Right if the `x-user-groups` header contains the given group', async () => {
+    const req: H.HttpRequest = {
+      ...aValidRequest,
+      headers: {
+        'x-user-groups': 'aGroup,anAnotherGroup',
+      },
+    };
+    const actual = verifyUserGroup('aGroup')(req);
+    expect(actual).toStrictEqual(E.right(void 0));
   });
 });

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
@@ -42,9 +42,9 @@ describe('verifyUserGroup', () => {
         'x-user-groups': 'aGroup,anAnotherGroup',
       },
     };
-    const actual = verifyUserGroup('anAdminGroup')(req);
+    const actual = verifyUserGroup('ApiTrialManager')(req);
     const expected = new H.HttpForbiddenError(
-      `Missing required group: anAdminGroup`,
+      `Missing required group: ApiTrialManager`,
     );
     expect(actual).toStrictEqual(E.left(expected));
   });
@@ -53,7 +53,7 @@ describe('verifyUserGroup', () => {
     const req: H.HttpRequest = {
       ...aValidRequest,
     };
-    const actual = verifyUserGroup('aGroup')(req);
+    const actual = verifyUserGroup('ApiTrialManager')(req);
     expect(actual).toStrictEqual(E.right(void 0));
   });
 
@@ -61,10 +61,10 @@ describe('verifyUserGroup', () => {
     const req: H.HttpRequest = {
       ...aValidRequest,
       headers: {
-        'x-user-groups': 'aGroup,anAnotherGroup',
+        'x-user-groups': 'aGroup,ApiTrialManager,anAnotherGroup',
       },
     };
-    const actual = verifyUserGroup('aGroup')(req);
+    const actual = verifyUserGroup('ApiTrialManager')(req);
     expect(actual).toStrictEqual(E.right(void 0));
   });
 });

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/update-activation-job.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/update-activation-job.test.ts
@@ -23,7 +23,6 @@ describe('makePutActivationJobHandler', () => {
     expect(actual.status).toStrictEqual(403);
     expect(await actual.json()).toMatchObject({
       status: 403,
-      detail: 'Missing required groups: ApiTrialManager',
     });
   });
 

--- a/apps/functions-subscription/src/adapters/azure/functions/create-trial.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/create-trial.ts
@@ -4,7 +4,7 @@ import * as H from '@pagopa/handler-kit';
 import { httpAzureFunction } from '@pagopa/handler-kit-azure-func';
 import { toHttpProblemJson } from './errors';
 import { SystemEnv } from '../../../system-env';
-import { parseRequestBody } from './middleware';
+import { parseRequestBody, verifyUserGroup } from './middleware';
 import { CreateTrial } from '../../../generated/definitions/internal/CreateTrial';
 import { toTrialAPI } from './codec';
 import { Trial as TrialAPI } from '../../../generated/definitions/internal/Trial';
@@ -19,6 +19,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Env>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
     RTE.apSW('requestBody', RTE.fromEither(parseRequestBody(CreateTrial)(req))),
     RTE.flatMapTaskEither(
       ({ requestBody: { name, description }, createTrial }) =>

--- a/apps/functions-subscription/src/adapters/azure/functions/get-activation-job.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/get-activation-job.ts
@@ -3,7 +3,7 @@ import { httpAzureFunction } from '@pagopa/handler-kit-azure-func';
 import { flow, pipe } from 'fp-ts/lib/function';
 import * as RTE from 'fp-ts/lib/ReaderTaskEither';
 import { SystemEnv } from '../../../system-env';
-import { parsePathParameter } from './middleware';
+import { parsePathParameter, verifyUserGroup } from './middleware';
 import { toHttpProblemJson } from './errors';
 import { ActivationJob as ActivationJobAPI } from '../../../generated/definitions/internal/ActivationJob';
 import { ItemNotFound } from '../../../domain/errors';
@@ -20,6 +20,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Env>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
     RTE.apSW(
       'trialId',
       RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/get-subscription.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/get-subscription.ts
@@ -5,7 +5,7 @@ import { httpAzureFunction } from '@pagopa/handler-kit-azure-func';
 import { Subscription as SubscriptionAPI } from '../../../generated/definitions/internal/Subscription';
 import { UserIdCodec } from '../../../domain/subscription';
 import { SystemEnv } from '../../../system-env';
-import { parsePathParameter } from './middleware';
+import { parsePathParameter, verifyUserGroup } from './middleware';
 import { toHttpProblemJson } from './errors';
 import { toSubscriptionAPI } from './codec';
 import { TrialIdCodec } from '../../../domain/trial';
@@ -18,6 +18,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) => {
   return pipe(
     RTE.ask<Pick<SystemEnv, 'getSubscription'>>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
     RTE.apSW(
       'userId',
       RTE.fromEither(parsePathParameter(UserIdCodec, 'userId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/get-trial.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/get-trial.ts
@@ -4,7 +4,7 @@ import * as RTE from 'fp-ts/ReaderTaskEither';
 import { httpAzureFunction } from '@pagopa/handler-kit-azure-func';
 import { Trial as TrialAPI } from '../../../generated/definitions/internal/Trial';
 import { SystemEnv } from '../../../system-env';
-import { parsePathParameter } from './middleware';
+import { parsePathParameter, verifyUserGroup } from './middleware';
 import { toHttpProblemJson } from './errors';
 import { toTrialAPI } from './codec';
 import { TrialIdCodec } from '../../../domain/trial';
@@ -20,6 +20,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Env>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
     RTE.apSW(
       'trialId',
       RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/insert-subscription.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/insert-subscription.ts
@@ -7,7 +7,11 @@ import { CreateSubscription } from '../../../generated/definitions/internal/Crea
 import { UserId } from '../../../domain/subscription';
 import { SystemEnv } from '../../../system-env';
 import { SubscriptionStoreError } from '../../../use-cases/errors';
-import { parsePathParameter, parseRequestBody } from './middleware';
+import {
+  parsePathParameter,
+  parseRequestBody,
+  verifyUserGroup,
+} from './middleware';
 import { toHttpProblemJson } from './errors';
 import { toSubscriptionAPI } from './codec';
 import { TrialIdCodec } from '../../../domain/trial';
@@ -21,6 +25,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) => {
   return pipe(
     RTE.ask<Pick<SystemEnv, 'createSubscription'>>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
     RTE.apSW(
       'requestBody',
       RTE.fromEither(parseRequestBody(CreateSubscription)(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
@@ -44,13 +44,12 @@ export const verifyUserGroup = (group: string) => (req: H.HttpRequest) =>
     req.headers['x-user-groups'],
     E.fromNullable(void 0),
     E.foldW(
+      // if x-user-groups does not exists behave like it were included
       E.right,
+      // if exists then verify if it is included
       flow(
         H.parse(t.string, `Invalid format of 'x-user-groups' header`),
-        E.mapLeft(
-          () => new H.HttpForbiddenError(`Missing required group: ${group}`),
-        ),
-        E.filterOrElse(
+        E.filterOrElseW(
           (stringGroups) => stringGroups.split(',').includes(group),
           () => new H.HttpForbiddenError(`Missing required group: ${group}`),
         ),

--- a/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
@@ -39,21 +39,22 @@ export const parsePathParameter =
  * `verifyUserGroup` permits the request as if the group were included in the
  * header.
  */
-export const verifyUserGroup = (group: string) => (req: H.HttpRequest) =>
-  pipe(
-    req.headers['x-user-groups'],
-    E.fromNullable(void 0),
-    E.foldW(
-      // if x-user-groups does not exists behave like it were included
-      E.right,
-      // if exists then verify if it is included
-      flow(
-        H.parse(t.string, `Invalid format of 'x-user-groups' header`),
-        E.filterOrElseW(
-          (stringGroups) => stringGroups.split(',').includes(group),
-          () => new H.HttpForbiddenError(`Missing required group: ${group}`),
+export const verifyUserGroup =
+  (group: 'ApiTrialManager') => (req: H.HttpRequest) =>
+    pipe(
+      req.headers['x-user-groups'],
+      E.fromNullable(void 0),
+      E.foldW(
+        // if x-user-groups does not exists behave like it were included
+        E.right,
+        // if exists then verify if it is included
+        flow(
+          H.parse(t.string, `Invalid format of 'x-user-groups' header`),
+          E.filterOrElseW(
+            (stringGroups) => stringGroups.split(',').includes(group),
+            () => new H.HttpForbiddenError(`Missing required group: ${group}`),
+          ),
+          E.map(() => void 0),
         ),
-        E.map(() => void 0),
       ),
-    ),
-  );
+    );

--- a/apps/functions-subscription/src/adapters/azure/functions/update-activation-job.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/update-activation-job.ts
@@ -5,7 +5,11 @@ import * as RTE from 'fp-ts/lib/ReaderTaskEither';
 import { SystemEnv } from '../../../system-env';
 import { UpdateActivationJob } from '../../../generated/definitions/internal/UpdateActivationJob';
 import { ActivationJob as ActivationJobAPI } from '../../../generated/definitions/internal/ActivationJob';
-import { parsePathParameter, parseRequestBody } from './middleware';
+import {
+  parsePathParameter,
+  parseRequestBody,
+  verifyUserGroup,
+} from './middleware';
 import { NonNegativeInteger } from '@pagopa/ts-commons/lib/numbers';
 import { toHttpProblemJson } from './errors';
 import { toActivationJobAPI } from './codec';
@@ -19,6 +23,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Pick<SystemEnv, 'updateActivationJob'>>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
     RTE.apSW(
       'trialId',
       RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Add a middleware to verify the user groups
- Add a check to ensure that `x-user-groups` contains the `ApiTrialManager` group to the following endpoints:
   - `POST /trials`
   - `GET /trials/{id}`
   - `PUT /trials/activation-job`
   - `GET /trials/activation-job`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The call from APIM provides the x-user-groups. The system must verify that a specific group is included for certain endpoints.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my code.
- [ ] I have committed only changes relevant to the task.
- [ ] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
