### PR TITLE
[IOPLT-619] Add PUT to update the subscription state

### DIFF
--- a/.changeset/fresh-zebras-push.md
+++ b/.changeset/fresh-zebras-push.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": minor
+---
+
+Add endpoint to update the `state` of a subscription

--- a/apps/functions-subscription/api/internal.yaml
+++ b/apps/functions-subscription/api/internal.yaml
@@ -54,6 +54,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+    put:
+      operationId: updateSubscription
+      summary: Update subscription
+      description: >-
+        Update the state of the subscription
+      parameters:
+        - $ref: '#/components/parameters/pathTrialId'
+        - $ref: '#/components/parameters/pathUserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSubscription'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdatedSubscription'
+        '400':
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
   /trials/{trialId}/subscriptions:
     post:
       operationId: createSubscription
@@ -309,6 +345,28 @@ components:
           $ref: '#/components/schemas/UserId'
         state:
           $ref: '#/components/schemas/CreateSubscriptionState'
+    UpdateSubscription:
+      description: >
+        Payload to update the state of the subscription.
+      type: object
+      required:
+        - state
+      properties:
+        state:
+          $ref: '#/components/schemas/SubscriptionState'
+    UpdatedSubscription:
+      type: object
+      required:
+        - trialId
+        - userId
+        - state
+      properties:
+        trialId:
+          $ref: '#/components/schemas/TrialId'
+        userId:
+          $ref: '#/components/schemas/UserId'
+        state:
+          $ref: '#/components/schemas/SubscriptionState'
     Subscription:
       type: object
       required:

--- a/apps/functions-subscription/api/internal.yaml
+++ b/apps/functions-subscription/api/internal.yaml
@@ -56,9 +56,9 @@ paths:
                 $ref: '#/components/schemas/ProblemJson'
     put:
       operationId: updateSubscription
-      summary: Update subscription
+      summary: Update a subscription
       description: >-
-        Update the state of the subscription
+        Update the state of a subscription
       parameters:
         - $ref: '#/components/parameters/pathTrialId'
         - $ref: '#/components/parameters/pathUserId'

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
@@ -109,7 +109,7 @@ describe('makeActivationRequestReaderWriter', () => {
     });
   });
 
-  describe('activate', () => {
+  describe('updateActivationRequestsState', () => {
     it('should not perform the update when there are no elements to update', async () => {
       const mockDB = makeDatabaseMock();
       const result = 'success' as const;
@@ -117,7 +117,7 @@ describe('makeActivationRequestReaderWriter', () => {
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
         containerName,
-      ).activate([])();
+      ).updateActivationRequestsState([], 'ACTIVE')();
 
       expect(actual).toStrictEqual(E.right(result));
       expect(mockDB.container('').items.batch).toHaveBeenCalledTimes(0);
@@ -138,7 +138,7 @@ describe('makeActivationRequestReaderWriter', () => {
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
         containerName,
-      ).activate(activationRequests)();
+      ).updateActivationRequestsState(activationRequests, 'ACTIVE')();
 
       expect(actual).toStrictEqual(E.right(result));
       expect(mockDB.container('').items.batch).toHaveBeenNthCalledWith(
@@ -171,7 +171,7 @@ describe('makeActivationRequestReaderWriter', () => {
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
         containerName,
-      ).activate(activationRequests)();
+      ).updateActivationRequestsState(activationRequests, 'ACTIVE')();
 
       expect(actual).toStrictEqual(E.right(result));
       expect(mockDB.container('').items.batch).toHaveBeenCalledTimes(
@@ -195,7 +195,7 @@ describe('makeActivationRequestReaderWriter', () => {
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
         containerName,
-      ).activate(activationRequests)();
+      ).updateActivationRequestsState(activationRequests, 'ACTIVE')();
 
       expect(actual).toStrictEqual(E.left(error));
       expect(mockDB.container('').items.batch).toHaveBeenNthCalledWith(
@@ -219,7 +219,7 @@ describe('makeActivationRequestReaderWriter', () => {
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
         containerName,
-      ).activate(activationRequests)();
+      ).updateActivationRequestsState(activationRequests, 'ACTIVE')();
 
       expect(actual).toStrictEqual(E.right(result));
       expect(mockDB.container('').items.batch).toHaveBeenNthCalledWith(

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
@@ -7,6 +7,7 @@ import { makeDatabaseMock } from './mocks';
 import {
   anActivationJob,
   anActivationRequest,
+  anActivationRequestActivated,
   anInsertActivationRequest,
 } from '../../../../domain/__tests__/data';
 import { makeActivationRequestReaderWriter } from '../activation-request';
@@ -69,7 +70,7 @@ const makeTestData = (length: number) => {
 describe('makeActivationRequestReaderWriter', () => {
   const containerName = 'aContainerName';
   describe('insert', () => {
-    it('should return the inserted item', async () => {
+    it('should return the inserted activation with subscribed state', async () => {
       const mockDB = makeDatabaseMock();
 
       mockDB
@@ -84,6 +85,58 @@ describe('makeActivationRequestReaderWriter', () => {
       expect(actual).toStrictEqual(E.right(anActivationRequest));
       expect(mockDB.container('').items.create).toBeCalledWith(
         anInsertActivationRequest,
+      );
+    });
+    it('should return the inserted activation with active state', async () => {
+      const mockDB = makeDatabaseMock();
+
+      mockDB.container('').items.batch.mockResolvedValueOnce({
+        result: [
+          {
+            statusCode: 200,
+            requestCharge: 1,
+            resourceBody: anActivationRequestActivated,
+          },
+          {
+            statusCode: 200,
+            requestCharge: 1,
+            resourceBody: anActivationJob,
+          },
+        ],
+      });
+
+      const activeInsertActivationRequest = {
+        ...anInsertActivationRequest,
+        state: 'ACTIVE' as const,
+      };
+
+      const actual = await makeActivationRequestReaderWriter(
+        mockDB as unknown as Database,
+        containerName,
+      ).insert(activeInsertActivationRequest)();
+
+      expect(actual).toStrictEqual(E.right(anActivationRequestActivated));
+      expect(mockDB.container('').items.batch).toBeCalledWith(
+        [
+          {
+            operationType: 'Create',
+            resourceBody: activeInsertActivationRequest,
+          },
+          {
+            id: activeInsertActivationRequest.trialId,
+            operationType: 'Patch',
+            resourceBody: {
+              operations: [
+                {
+                  op: 'incr',
+                  path: `/usersActivated`,
+                  value: 1,
+                },
+              ],
+            },
+          },
+        ],
+        activeInsertActivationRequest.trialId,
       );
     });
     it('should return ItemAlreadyExists if the item already exists', async () => {

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
@@ -39,25 +39,28 @@ export const makeActivationRequestReaderWriter = (
           ? pipe(
               TE.tryCatch(
                 () =>
-                  container.items.batch([
-                    {
-                      operationType: BulkOperationType.Create,
-                      resourceBody: insertActivationRequest,
-                    },
-                    {
-                      id: insertActivationRequest.trialId,
-                      operationType: BulkOperationType.Patch,
-                      resourceBody: {
-                        operations: [
-                          {
-                            op: PatchOperationType.incr,
-                            path: `/usersActivated`,
-                            value: 1,
-                          },
-                        ],
+                  container.items.batch(
+                    [
+                      {
+                        operationType: BulkOperationType.Create,
+                        resourceBody: insertActivationRequest,
                       },
-                    },
-                  ]),
+                      {
+                        id: insertActivationRequest.trialId,
+                        operationType: BulkOperationType.Patch,
+                        resourceBody: {
+                          operations: [
+                            {
+                              op: PatchOperationType.incr,
+                              path: `/usersActivated`,
+                              value: 1,
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    insertActivationRequest.trialId,
+                  ),
                 E.toError,
               ),
               TE.flatMapEither(({ result }) =>

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
@@ -90,9 +90,8 @@ export const makeActivationRequestReaderWriter = (
           E.toError,
         ),
         TE.flatMapEither(decodeFromFeed(ActivationRequestCodec)),
-        TE.map(RA.head),
+        TE.mapBoth(cosmosErrorToDomainError, RA.head),
       ),
-    // This method should decrease the counter of the job by the number of activationRequests with state = "ACTIVE"
     updateActivationRequestsState: (activationRequests, state) =>
       pipe(
         RNEA.fromReadonlyArray(activationRequests),

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/decode.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/decode.ts
@@ -2,23 +2,38 @@ import * as t from 'io-ts';
 import { pipe } from 'fp-ts/lib/function';
 import * as E from 'fp-ts/lib/Either';
 import * as O from 'fp-ts/lib/Option';
-import { ItemResponse, ItemDefinition, FeedResponse } from '@azure/cosmos';
+import {
+  ItemResponse,
+  ItemDefinition,
+  FeedResponse,
+  OperationResponse,
+} from '@azure/cosmos';
 
-export const decodeFromItem =
+const resourceDecode =
   <A, O>(codec: t.Type<A, O>) =>
-  <T extends ItemDefinition>(item: ItemResponse<T>) =>
+  <T extends { readonly id?: string }>(resource: T | undefined) =>
     pipe(
-      O.fromNullable(item.resource),
+      O.fromNullable(resource),
       O.map(codec.decode),
       // transform Option<Either<L, R>> => Either<L, Option<R>>
       O.sequence(E.Applicative),
       E.mapLeft(
         () =>
           new Error(
-            `Unable to parse the ${item.resource?.id} using codec ${codec.name}`,
+            `Unable to parse the ${resource?.id} using codec ${codec.name}`,
           ),
       ),
     );
+
+export const decodeFromItem =
+  <A, O>(codec: t.Type<A, O>) =>
+  <T extends ItemDefinition>(item: ItemResponse<T>) =>
+    resourceDecode(codec)(item.resource);
+
+export const decodeFromOperationResponse =
+  <A, O>(codec: t.Type<A, O>) =>
+  (item: OperationResponse) =>
+    resourceDecode(codec)(item.resourceBody);
 
 export const decodeFromFeed =
   <A, O>(codec: t.Type<A, O>) =>

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/data.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/data.ts
@@ -4,6 +4,7 @@ import { UserId } from '../../../../generated/definitions/internal/UserId';
 import { TrialId } from '../../../../generated/definitions/internal/TrialId';
 import { CreateSubscriptionStateEnum } from '../../../../generated/definitions/internal/CreateSubscriptionState';
 import { anActivationJob, aTrial } from '../../../../domain/__tests__/data';
+import { UpdateSubscription } from '../../../../generated/definitions/internal/UpdateSubscription';
 
 const aUserId = 'aUserId' as UserId;
 const aTrialId = 'aTrialId' as TrialId;
@@ -35,6 +36,18 @@ export const makeAValidGetSubscriptionRequest = () =>
   new HttpRequest({
     url: 'https://function/trials/{trialId}/subscriptions/{userId}',
     method: 'GET',
+    params: {
+      trialId: aTrialId,
+      userId: aUserId,
+    },
+  });
+
+export const makeAValidUpdateSubscriptionRequest = (body: UpdateSubscription) =>
+  new HttpRequest({
+    url: 'https://function/trials/{trialId}/subscriptions/{userId}',
+    method: 'PUT',
+    headers: { 'x-user-groups': 'ApiTrialManager' },
+    body: { string: JSON.stringify(body) },
     params: {
       trialId: aTrialId,
       userId: aUserId,

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/mocks.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/mocks.ts
@@ -14,6 +14,7 @@ export const makeTestSystemEnv = () => ({
   createSubscription: mockFn<SystemEnv['createSubscription']>(),
   processSubscriptionRequest: mockFn<SystemEnv['processSubscriptionRequest']>(),
   getSubscription: mockFn<SystemEnv['getSubscription']>(),
+  updateSubscription: mockFn<SystemEnv['updateSubscription']>(),
   processActivationJob: mockFn<SystemEnv['processActivationJob']>(),
   processActivationRequest: mockFn<SystemEnv['processActivationRequest']>(),
   createTrial: mockFn<SystemEnv['createTrial']>(),

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/update-subscription.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/update-subscription.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import * as TE from 'fp-ts/TaskEither';
+import { HttpRequest } from '@azure/functions';
+import { makeAValidUpdateSubscriptionRequest } from './data';
+import { makeFunctionContext, makeTestSystemEnv } from './mocks';
+import { anActivationRequest } from '../../../../domain/__tests__/data';
+import { ItemNotFound } from '../../../../domain/errors';
+import { makePutSubscriptionHandler } from '../update-subscription';
+import { SubscriptionStateEnum } from '../../../../generated/definitions/internal/SubscriptionState';
+
+describe('makeUpdateSubscriptionHandler', () => {
+  const anUpdateSubscription = {
+    state: SubscriptionStateEnum.DISABLED,
+  };
+  it('should return 403 if x-user-groups header does not contain the correct group', async () => {
+    const baseRequest =
+      makeAValidUpdateSubscriptionRequest(anUpdateSubscription);
+    const request = new HttpRequest({
+      url: baseRequest.url,
+      method: baseRequest.method,
+      headers: { 'x-user-groups': 'Guest,AnotherGroup' },
+      body: { string: await baseRequest.text() },
+      params: baseRequest.params,
+    });
+    const env = makeTestSystemEnv();
+    const actual = await makePutSubscriptionHandler(env)(
+      request,
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(403);
+    expect(await actual.json()).toMatchObject({
+      status: 403,
+    });
+  });
+
+  it('should return 202', async () => {
+    const env = makeTestSystemEnv();
+    env.updateSubscription.mockReturnValueOnce(TE.right(anActivationRequest));
+
+    const actual = await makePutSubscriptionHandler(env)(
+      makeAValidUpdateSubscriptionRequest(anUpdateSubscription),
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(202);
+    expect(env.updateSubscription).toHaveBeenCalledWith(
+      anActivationRequest.userId,
+      anActivationRequest.trialId,
+      anUpdateSubscription.state,
+    );
+  });
+
+  it('should return 400 when the request body is not valid', async () => {
+    const baseRequest =
+      makeAValidUpdateSubscriptionRequest(anUpdateSubscription);
+    const aRequestWithInvalidBody = new HttpRequest({
+      url: baseRequest.url,
+      method: baseRequest.method,
+      headers: { 'x-user-groups': 'ApiTrialManager' },
+      body: { string: '{}' },
+      params: baseRequest.params,
+    });
+    const env = makeTestSystemEnv();
+    const actual = await makePutSubscriptionHandler(env)(
+      aRequestWithInvalidBody,
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(400);
+    expect(await actual.json()).toMatchObject({
+      status: 400,
+      detail: 'Missing or invalid body',
+    });
+  });
+
+  it('should return 404 when the subscription does not exist', async () => {
+    const env = makeTestSystemEnv();
+    const error = new ItemNotFound('Not Found');
+    env.updateSubscription.mockReturnValueOnce(TE.left(error));
+    const actual = await makePutSubscriptionHandler(env)(
+      makeAValidUpdateSubscriptionRequest(anUpdateSubscription),
+      makeFunctionContext(),
+    );
+    expect(actual.status).toStrictEqual(404);
+    expect(await actual.json()).toMatchObject({
+      status: 404,
+      detail: error.message,
+    });
+  });
+
+  it('should return 500 when the use case returned an error', async () => {
+    const env = makeTestSystemEnv();
+    const error = new Error('Something went wrong');
+    env.updateSubscription.mockReturnValueOnce(TE.left(error));
+
+    const actual = await makePutSubscriptionHandler(env)(
+      makeAValidUpdateSubscriptionRequest(anUpdateSubscription),
+      makeFunctionContext(),
+    );
+
+    expect(actual.status).toStrictEqual(500);
+    expect(await actual.json()).toMatchObject({
+      status: 500,
+      detail: error.message,
+    });
+  });
+});

--- a/apps/functions-subscription/src/adapters/azure/functions/codec.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/codec.ts
@@ -6,6 +6,8 @@ import { Subscription as SubscriptionAPI } from '../../../generated/definitions/
 import { SubscriptionStateEnum } from '../../../generated/definitions/internal/SubscriptionState';
 import { TrialStateEnum } from '../../../generated/definitions/internal/TrialState';
 import { Trial as TrialAPI } from '../../../generated/definitions/internal/Trial';
+import { ActivationRequest } from '../../../domain/activation-request';
+import { UpdatedSubscription } from '../../../generated/definitions/internal/UpdatedSubscription';
 
 export const toSubscriptionAPI = (
   subscription: Subscription,
@@ -15,6 +17,14 @@ export const toSubscriptionAPI = (
   state: SubscriptionStateEnum[subscription.state],
   createdAt: subscription.createdAt,
   updatedAt: subscription.updatedAt,
+});
+
+export const toUpdatedSubscription = (
+  activationRequest: ActivationRequest,
+): UpdatedSubscription => ({
+  trialId: activationRequest.trialId,
+  userId: activationRequest.userId,
+  state: SubscriptionStateEnum[activationRequest.state],
 });
 
 export const toActivationJobAPI = (

--- a/apps/functions-subscription/src/adapters/azure/functions/update-subscription.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/update-subscription.ts
@@ -1,0 +1,53 @@
+import * as H from '@pagopa/handler-kit';
+import { pipe, flow } from 'fp-ts/lib/function';
+import * as RTE from 'fp-ts/ReaderTaskEither';
+import { httpAzureFunction } from '@pagopa/handler-kit-azure-func';
+import { UserIdCodec } from '../../../domain/subscription';
+import { SystemEnv } from '../../../system-env';
+import {
+  parsePathParameter,
+  parseRequestBody,
+  verifyUserGroup,
+} from './middleware';
+import { toHttpProblemJson } from './errors';
+import { toUpdatedSubscription } from './codec';
+import { TrialIdCodec } from '../../../domain/trial';
+import { UpdatedSubscription } from '../../../generated/definitions/internal/UpdatedSubscription';
+import { UpdateSubscription } from '../../../generated/definitions/internal/UpdateSubscription';
+
+const makeHandlerKitHandler: H.Handler<
+  H.HttpRequest,
+  | H.HttpResponse<UpdatedSubscription, 202>
+  | H.HttpResponse<H.ProblemJson, H.HttpErrorStatusCode>,
+  Pick<SystemEnv, 'updateSubscription'>
+> = H.of((req: H.HttpRequest) => {
+  return pipe(
+    RTE.ask<Pick<SystemEnv, 'updateSubscription'>>(),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apSW(
+      'userId',
+      RTE.fromEither(parsePathParameter(UserIdCodec, 'userId')(req)),
+    ),
+    RTE.apSW(
+      'trialId',
+      RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),
+    ),
+    RTE.apSW(
+      'requestBody',
+      RTE.fromEither(parseRequestBody(UpdateSubscription)(req)),
+    ),
+    RTE.flatMapTaskEither(
+      ({ updateSubscription, trialId, userId, requestBody }) =>
+        updateSubscription(userId, trialId, requestBody.state),
+    ),
+    RTE.mapBoth(
+      toHttpProblemJson,
+      flow(toUpdatedSubscription, H.successJson, H.withStatusCode(202)),
+    ),
+    RTE.orElseW(RTE.of),
+  );
+});
+
+export const makePutSubscriptionHandler = httpAzureFunction(
+  makeHandlerKitHandler,
+);

--- a/apps/functions-subscription/src/domain/activation-request.ts
+++ b/apps/functions-subscription/src/domain/activation-request.ts
@@ -58,22 +58,9 @@ export interface ActivationRequestWriter {
     activationRequest: InsertActivationRequest,
   ) => TE.TaskEither<Error | ItemAlreadyExists, ActivationRequest>;
   /**
-   * This function is responsible to activate the activation requests.
-   * If any of the activation request cannot be activated, then none of them
-   * are activated.
-   * All the activation request must be of the same trialId.
-   */
-  readonly activate: (
-    activationRequests: readonly ActivationRequest[],
-  ) => TE.TaskEither<Error, ActivationResult>;
-  /**
    * This function is responsible to change the state of active activation requests.
    * This will also update the counter of the activation job decreasing it by
    * the number of activation requests with ACTIVE state.
-   *
-   * This function should not be used to activate.
-   * If you want to activate any activation requests, then use
-   * {@link activate} method.
    */
   readonly updateActivationRequestsState: (
     activationRequests: readonly ActivationRequest[],
@@ -118,17 +105,7 @@ export const getActivationRequest = (
     ),
   );
 
-export const activateActivationRequests = (
-  requests: readonly ActivationRequest[],
-) =>
-  pipe(
-    RTE.ask<Pick<Capabilities, 'activationRequestWriter'>>(),
-    RTE.flatMapTaskEither(({ activationRequestWriter }) =>
-      activationRequestWriter.activate(requests),
-    ),
-  );
-
-export const updateState = (
+export const updateActivationRequestState = (
   requests: readonly ActivationRequest[],
   state: ActivationRequest['state'],
 ) =>

--- a/apps/functions-subscription/src/domain/activation-request.ts
+++ b/apps/functions-subscription/src/domain/activation-request.ts
@@ -58,9 +58,15 @@ export interface ActivationRequestWriter {
     activationRequest: InsertActivationRequest,
   ) => TE.TaskEither<Error | ItemAlreadyExists, ActivationRequest>;
   /**
-   * This function is responsible to change the state of active activation requests.
-   * This will also update the counter of the activation job decreasing it by
-   * the number of activation requests with ACTIVE state.
+   * Updates the state of activation requests and adjusts the activation job counter accordingly.
+   *
+   * This function changes the state of the provided activation requests and updates the counter
+   * of the activation job by increasing or decreasing it based on the number of activation requests
+   * and their new state.
+   *
+   * @param activationRequests - An array of activation requests to be updated.
+   * @param state - The new state to assign to the activation requests.
+   * @returns A TaskEither that resolves to an {@link ActivationRequest} or an {@link Error}.
    */
   readonly updateActivationRequestsState: (
     activationRequests: readonly ActivationRequest[],

--- a/apps/functions-subscription/src/main.ts
+++ b/apps/functions-subscription/src/main.ts
@@ -34,6 +34,7 @@ import { ManagedServiceIdentityClient } from '@azure/arm-msi';
 import { AuthorizationManagementClient } from '@azure/arm-authorization';
 import { ServiceBusManagementClient } from '@azure/arm-servicebus';
 import { makeChannelAdminServiceBus } from './adapters/azure/servicebus/channel';
+import { makePutSubscriptionHandler } from './adapters/azure/functions/update-subscription';
 
 const config = pipe(
   parseConfig(process.env),
@@ -162,6 +163,13 @@ app.http('getSubscription', {
   methods: ['GET'],
   authLevel: 'function',
   handler: makeGetSubscriptionHandler(env),
+  route: 'trials/{trialId}/subscriptions/{userId}',
+});
+
+app.http('updateSubscription', {
+  methods: ['PUT'],
+  authLevel: 'function',
+  handler: makePutSubscriptionHandler(env),
   route: 'trials/{trialId}/subscriptions/{userId}',
 });
 

--- a/apps/functions-subscription/src/system-env.ts
+++ b/apps/functions-subscription/src/system-env.ts
@@ -7,10 +7,12 @@ import { processActivationJob } from './use-cases/process-activation-job';
 import { processActivationRequest } from './use-cases/process-activation-request';
 import { getActivationJob, updateActivationJob } from './domain/activation-job';
 import { insertTrial, getTrialById } from './domain/trial';
+import { updateSubscription } from './use-cases/update-subscription';
 
 export const makeSystemEnv = (capabilities: Capabilities) => ({
   createSubscription: flow(createSubscription, apply(capabilities)),
   getSubscription: flow(getSubscription, apply(capabilities)),
+  updateSubscription: flow(updateSubscription, apply(capabilities)),
   processSubscriptionRequest: flow(
     processSubscriptionRequest,
     apply(capabilities),

--- a/apps/functions-subscription/src/use-cases/__tests__/process-activation-job.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-activation-job.test.ts
@@ -34,7 +34,7 @@ describe('processActivationJob', () => {
     mockEnv.activationRequestReader.list.mockReturnValueOnce(
       TE.right(activationRequests),
     );
-    mockEnv.activationRequestWriter.activate.mockReturnValue(
+    mockEnv.activationRequestWriter.updateActivationRequestsState.mockReturnValue(
       TE.right('success' as const),
     );
 
@@ -49,9 +49,9 @@ describe('processActivationJob', () => {
       activationJob.trialId,
       fetchSize,
     );
-    expect(mockEnv.activationRequestWriter.activate).toHaveBeenCalledWith(
-      activationRequests,
-    );
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toHaveBeenCalledWith(activationRequests, 'ACTIVE');
   });
   it(`should activate only ${maxFetchSize} elements`, async () => {
     const mockEnv = makeTestEnv();
@@ -71,7 +71,7 @@ describe('processActivationJob', () => {
     mockEnv.activationRequestReader.list.mockReturnValueOnce(
       TE.right(activationRequests),
     );
-    mockEnv.activationRequestWriter.activate.mockReturnValue(
+    mockEnv.activationRequestWriter.updateActivationRequestsState.mockReturnValue(
       TE.right('success' as const),
     );
 
@@ -86,9 +86,9 @@ describe('processActivationJob', () => {
       activationJob.trialId,
       maxFetchSize,
     );
-    expect(mockEnv.activationRequestWriter.activate).toHaveBeenCalledWith(
-      activationRequests,
-    );
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toHaveBeenCalledWith(activationRequests, 'ACTIVE');
   });
   it('should activate when there is at least an activation request', async () => {
     const mockEnv = makeTestEnv();
@@ -98,7 +98,7 @@ describe('processActivationJob', () => {
     mockEnv.activationRequestReader.list.mockReturnValueOnce(
       TE.right(activationRequests),
     );
-    mockEnv.activationRequestWriter.activate.mockReturnValue(
+    mockEnv.activationRequestWriter.updateActivationRequestsState.mockReturnValue(
       TE.right('success'),
     );
 
@@ -109,10 +109,9 @@ describe('processActivationJob', () => {
     const expected = E.right('success');
 
     expect(actual).toStrictEqual(expected);
-    expect(mockEnv.activationRequestWriter.activate).toHaveBeenNthCalledWith(
-      1,
-      activationRequests,
-    );
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toHaveBeenNthCalledWith(1, activationRequests, 'ACTIVE');
   });
   it('should activate just one batch when one succeed and one fail', async () => {
     const mockEnv = makeTestEnv();
@@ -129,7 +128,7 @@ describe('processActivationJob', () => {
     mockEnv.activationRequestReader.list.mockReturnValueOnce(
       TE.right(activationRequests),
     );
-    mockEnv.activationRequestWriter.activate
+    mockEnv.activationRequestWriter.updateActivationRequestsState
       .mockReturnValueOnce(TE.right('success' as const))
       .mockReturnValueOnce(TE.right('fail' as const));
 
@@ -140,16 +139,16 @@ describe('processActivationJob', () => {
     const expected = E.right('success');
 
     expect(actual).toStrictEqual(expected);
-    expect(mockEnv.activationRequestWriter.activate).toHaveBeenCalledWith(
-      activationRequests,
-    );
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toHaveBeenCalledWith(activationRequests, 'ACTIVE');
   });
   it('should return success when there are no activation requests', async () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 
     mockEnv.activationRequestReader.list.mockReturnValueOnce(TE.right([]));
-    mockEnv.activationRequestWriter.activate.mockReturnValueOnce(
+    mockEnv.activationRequestWriter.updateActivationRequestsState.mockReturnValueOnce(
       TE.right('success' as const),
     );
 
@@ -173,7 +172,9 @@ describe('processActivationJob', () => {
 
     expect(actual).toStrictEqual(expected);
     expect(mockEnv.activationRequestReader.list).toBeCalledTimes(0);
-    expect(mockEnv.activationRequestWriter.activate).toBeCalledTimes(0);
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toBeCalledTimes(0);
   });
 
   it('should return an error when the fetch fail', async () => {
@@ -192,6 +193,8 @@ describe('processActivationJob', () => {
     const expected = E.left(unexpectedError);
 
     expect(actual).toStrictEqual(expected);
-    expect(mockEnv.activationRequestWriter.activate).toHaveBeenCalledTimes(0);
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toHaveBeenCalledTimes(0);
   });
 });

--- a/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
@@ -33,7 +33,7 @@ describe('processActivationRequest', () => {
     expect(mockEnv.subscriptionHistoryWriter.insert).toBeCalledTimes(0);
   });
 
-  it('should create a new version of subscription-history when state changed', async () => {
+  it('should create a new version of subscription-history when the state changes', async () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 

--- a/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-activation-request.test.ts
@@ -9,24 +9,11 @@ import {
   aSubscription,
   aSubscriptionHistory,
   aSubscriptionHistoryV1,
-  anActivationRequest,
   anActivationRequestActivated,
 } from '../../domain/__tests__/data';
 
 describe('processActivationRequest', () => {
-  it('should return none if activation request is not activated', async () => {
-    const mockEnv = makeTestEnv();
-    const testEnv = mockEnv as unknown as Capabilities;
-
-    const actual =
-      await processActivationRequest(anActivationRequest)(testEnv)();
-
-    expect(actual).toStrictEqual(E.right(O.none));
-    expect(mockEnv.subscriptionHistoryReader.getLatest).toBeCalledTimes(0);
-    expect(mockEnv.subscriptionHistoryWriter.insert).toBeCalledTimes(0);
-  });
-
-  it('should not insert a new version if the latest subscription-history is not SUBSCRIBED', async () => {
+  it('should not insert a new version when state does not change', async () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 
@@ -46,7 +33,7 @@ describe('processActivationRequest', () => {
     expect(mockEnv.subscriptionHistoryWriter.insert).toBeCalledTimes(0);
   });
 
-  it('should create a new version of subscription-history if activated and the latest version is SUBSCRIBED', async () => {
+  it('should create a new version of subscription-history when state changed', async () => {
     const mockEnv = makeTestEnv();
     const testEnv = mockEnv as unknown as Capabilities;
 

--- a/apps/functions-subscription/src/use-cases/__tests__/process-subscription-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-subscription-request.test.ts
@@ -61,7 +61,7 @@ describe('processSubscriptionRequest', () => {
     mockEnv.activationRequestWriter.insert.mockReturnValueOnce(
       TE.right({ ...anActivationRequest, state: 'ACTIVE' }),
     );
-    mockEnv.activationRequestWriter.activate.mockReturnValueOnce(
+    mockEnv.activationRequestWriter.updateActivationRequestsState.mockReturnValueOnce(
       TE.right('success'),
     );
 
@@ -71,9 +71,9 @@ describe('processSubscriptionRequest', () => {
     })(testEnv)();
 
     expect(actual).toStrictEqual(E.right({ userId, trialId }));
-    expect(mockEnv.activationRequestWriter.activate).toBeCalledWith([
-      { ...anActivationRequest, state: 'ACTIVE' },
-    ]);
+    expect(
+      mockEnv.activationRequestWriter.updateActivationRequestsState,
+    ).toBeCalledWith([{ ...anActivationRequest, state: 'ACTIVE' }], 'ACTIVE');
   });
   it('should not call activate if the request is neither ACTIVE nor SUBSCRIBED', async () => {
     const mockEnv = makeTestEnv();

--- a/apps/functions-subscription/src/use-cases/__tests__/update-subscription.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/update-subscription.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import * as TE from 'fp-ts/TaskEither';
+import * as O from 'fp-ts/Option';
+import * as E from 'fp-ts/Either';
+import { anActivationRequest } from '../../domain/__tests__/data';
+import { makeTestEnv } from '../../domain/__tests__/mocks';
+import { ItemNotFound } from '../../domain/errors';
+import { updateSubscription } from '../update-subscription';
+
+const { userId, trialId } = anActivationRequest;
+
+describe('updateSubscription', () => {
+  it('should return ItemNotFound if the activation request does not exist', async () => {
+    const env = makeTestEnv();
+
+    env.activationRequestReader.get.mockReturnValueOnce(TE.right(O.none));
+
+    const actual = await updateSubscription(userId, trialId, 'DISABLED')(env)();
+
+    expect(actual).toStrictEqual(
+      E.left(new ItemNotFound('Subscription not found')),
+    );
+  });
+  it('should disable the activation request', async () => {
+    const env = makeTestEnv();
+
+    env.activationRequestReader.get.mockReturnValueOnce(
+      TE.right(O.some(anActivationRequest)),
+    );
+    env.activationRequestWriter.updateActivationRequestsState.mockReturnValueOnce(
+      TE.right('success'),
+    );
+
+    const actual = await updateSubscription(userId, trialId, 'DISABLED')(env)();
+
+    const updatedSubscription = {
+      ...anActivationRequest,
+      state: 'DISABLED',
+    };
+    expect(actual).toStrictEqual(E.right(updatedSubscription));
+    expect(env.activationRequestReader.get).toHaveBeenNthCalledWith(
+      1,
+      anActivationRequest.trialId,
+      anActivationRequest.userId,
+    );
+    expect(
+      env.activationRequestWriter.updateActivationRequestsState,
+    ).toHaveBeenNthCalledWith(
+      1,
+      [anActivationRequest],
+      updatedSubscription.state,
+    );
+  });
+
+  it('should not do anything when the state properties have the same values', async () => {
+    const env = makeTestEnv();
+
+    env.activationRequestReader.get.mockReturnValueOnce(
+      TE.right(O.some(anActivationRequest)),
+    );
+
+    const actual = await updateSubscription(
+      userId,
+      trialId,
+      'SUBSCRIBED',
+    )(env)();
+
+    expect(actual).toStrictEqual(E.right(anActivationRequest));
+    expect(env.activationRequestReader.get).toHaveBeenNthCalledWith(
+      1,
+      anActivationRequest.trialId,
+      anActivationRequest.userId,
+    );
+    expect(
+      env.activationRequestWriter.updateActivationRequestsState,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should return error if something fail', async () => {
+    const testEnv = makeTestEnv();
+    const error = new Error('Oh No!');
+
+    testEnv.activationRequestReader.get.mockReturnValueOnce(TE.left(error));
+
+    const actual = await updateSubscription(
+      userId,
+      trialId,
+      'DISABLED',
+    )(testEnv)();
+    const expected = E.left(error);
+    expect(actual).toMatchObject(expected);
+  });
+});

--- a/apps/functions-subscription/src/use-cases/process-activation-job.ts
+++ b/apps/functions-subscription/src/use-cases/process-activation-job.ts
@@ -25,7 +25,10 @@ export const processActivationJob = (
           : pipe(
               activationRequestReader.list(job.trialId, limit),
               TE.flatMap((activationRequests) =>
-                activationRequestWriter.activate(activationRequests),
+                activationRequestWriter.updateActivationRequestsState(
+                  activationRequests,
+                  'ACTIVE',
+                ),
               ),
             ),
     ),

--- a/apps/functions-subscription/src/use-cases/process-subscription-request.ts
+++ b/apps/functions-subscription/src/use-cases/process-subscription-request.ts
@@ -8,9 +8,9 @@ import {
 } from '../domain/subscription-history';
 import {
   ActivationRequest,
-  activateActivationRequests,
   insertActivationRequest,
   makeInsertActivationRequest,
+  updateActivationRequestState,
 } from '../domain/activation-request';
 
 const recoverItemAlreadyExists =
@@ -26,7 +26,7 @@ const handleActivatedRequest = (request: ActivationRequest) =>
     ? pipe(
         // This operation is required to keep the number of activated users up to date.
         // The assumption is that the activation job exists.
-        activateActivationRequests([request]),
+        updateActivationRequestState([request], 'ACTIVE'),
         RTE.map(() => request),
       )
     : RTE.of(request);

--- a/apps/functions-subscription/src/use-cases/process-subscription-request.ts
+++ b/apps/functions-subscription/src/use-cases/process-subscription-request.ts
@@ -7,10 +7,8 @@ import {
   makeSubscriptionHistory,
 } from '../domain/subscription-history';
 import {
-  ActivationRequest,
   insertActivationRequest,
   makeInsertActivationRequest,
-  updateActivationRequestState,
 } from '../domain/activation-request';
 
 const recoverItemAlreadyExists =
@@ -21,34 +19,21 @@ const recoverItemAlreadyExists =
     else return RTE.left(error);
   };
 
-const handleActivatedRequest = (request: ActivationRequest) =>
-  request.state === 'ACTIVE'
-    ? pipe(
-        // This operation is required to keep the number of activated users up to date.
-        // The assumption is that the activation job exists.
-        updateActivationRequestState([request], 'ACTIVE'),
-        RTE.map(() => request),
-      )
-    : RTE.of(request);
-
 export const processSubscriptionRequest = (subscription: Subscription) =>
   pipe(
     makeSubscriptionHistory(subscription),
     RTE.flatMap(insertSubscriptionHistory),
     RTE.orElseW(recoverItemAlreadyExists(subscription)),
     RTE.flatMap(() =>
-      subscription.state === 'SUBSCRIBED' || subscription.state === 'ACTIVE'
-        ? pipe(
-            makeInsertActivationRequest({
-              trialId: subscription.trialId,
-              userId: subscription.userId,
-              state: subscription.state,
-            }),
-            RTE.flatMap(insertActivationRequest),
-            RTE.flatMap(handleActivatedRequest),
-            RTE.orElseW(recoverItemAlreadyExists(subscription)),
-          )
-        : RTE.of(subscription),
+      pipe(
+        makeInsertActivationRequest({
+          trialId: subscription.trialId,
+          userId: subscription.userId,
+          state: subscription.state,
+        }),
+        RTE.flatMap(insertActivationRequest),
+        RTE.orElseW(recoverItemAlreadyExists(subscription)),
+      ),
     ),
     RTE.map(() => ({
       trialId: subscription.trialId,

--- a/apps/functions-subscription/src/use-cases/update-subscription.ts
+++ b/apps/functions-subscription/src/use-cases/update-subscription.ts
@@ -3,21 +3,10 @@ import * as RTE from 'fp-ts/ReaderTaskEither';
 import { Subscription, UserId } from '../domain/subscription';
 import { TrialId } from '../domain/trial';
 import {
-  activateActivationRequests,
-  ActivationRequest,
-  updateState,
+  updateActivationRequestState,
   getActivationRequest,
 } from '../domain/activation-request';
 import { ItemNotFound } from '../domain/errors';
-
-const handleUpdateSubscriptionState = (
-  activationRequest: ActivationRequest,
-  newState: Subscription['state'],
-) => {
-  if (newState === 'ACTIVE')
-    return activateActivationRequests([activationRequest]);
-  else return updateState([activationRequest], newState);
-};
 
 export const updateSubscription = (
   userId: UserId,
@@ -33,7 +22,7 @@ export const updateSubscription = (
     RTE.flatMap((req) => {
       if (state !== req.state) {
         return pipe(
-          handleUpdateSubscriptionState(req, state),
+          updateActivationRequestState([req], state),
           RTE.flatMap(() => RTE.of({ ...req, state })),
         );
       } else {

--- a/apps/functions-subscription/src/use-cases/update-subscription.ts
+++ b/apps/functions-subscription/src/use-cases/update-subscription.ts
@@ -23,7 +23,7 @@ export const updateSubscription = (
       if (state !== req.state) {
         return pipe(
           updateActivationRequestState([req], state),
-          RTE.flatMap(() => RTE.of({ ...req, state })),
+          RTE.map(() => ({ ...req, state })),
         );
       } else {
         return RTE.of(req);

--- a/apps/functions-subscription/src/use-cases/update-subscription.ts
+++ b/apps/functions-subscription/src/use-cases/update-subscription.ts
@@ -1,0 +1,43 @@
+import { pipe } from 'fp-ts/lib/function';
+import * as RTE from 'fp-ts/ReaderTaskEither';
+import { Subscription, UserId } from '../domain/subscription';
+import { TrialId } from '../domain/trial';
+import {
+  activateActivationRequests,
+  ActivationRequest,
+  updateState,
+  getActivationRequest,
+} from '../domain/activation-request';
+import { ItemNotFound } from '../domain/errors';
+
+const handleUpdateSubscriptionState = (
+  activationRequest: ActivationRequest,
+  newState: Subscription['state'],
+) => {
+  if (newState === 'ACTIVE')
+    return activateActivationRequests([activationRequest]);
+  else return updateState([activationRequest], newState);
+};
+
+export const updateSubscription = (
+  userId: UserId,
+  trialId: TrialId,
+  state: Subscription['state'],
+) =>
+  pipe(
+    getActivationRequest(trialId, userId),
+    RTE.flatMapOption(
+      (req) => req,
+      () => new ItemNotFound('Subscription not found'),
+    ),
+    RTE.flatMap((req) => {
+      if (state !== req.state) {
+        return pipe(
+          handleUpdateSubscriptionState(req, state),
+          RTE.flatMap(() => RTE.of({ ...req, state })),
+        );
+      } else {
+        return RTE.of(req);
+      }
+    }),
+  );

--- a/infra/resources/modules/commons/containers.tf
+++ b/infra/resources/modules/commons/containers.tf
@@ -97,12 +97,12 @@ resource "azurerm_cosmosdb_sql_container" "activation" {
       }
 
       index {
-        path  = "/userId"
+        path  = "/type"
         order = "Ascending"
       }
 
       index {
-        path  = "/type"
+        path  = "/userId"
         order = "Ascending"
       }
     }

--- a/infra/resources/modules/commons/containers.tf
+++ b/infra/resources/modules/commons/containers.tf
@@ -89,6 +89,23 @@ resource "azurerm_cosmosdb_sql_container" "activation" {
         order = "Ascending"
       }
     }
+
+    composite_index {
+      index {
+        path  = "/trialId"
+        order = "Ascending"
+      }
+
+      index {
+        path  = "/userId"
+        order = "Ascending"
+      }
+
+      index {
+        path  = "/type"
+        order = "Ascending"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `PUT /trials/{trialId}/subscriptions/{userId}` to the OpenAPI
- Update the `insert` on activation requests
    - Now, if the activation request to insert is `ACTIVE`, perform the insert within a transactional batch (which updates the `usersActivated` counter in the same transaction)
- Rename `activate` function to `updateActivationRequestsState`
    - Use a single function to handle the `state` changes of the activation
- Improve CosmosDB codec to parse `OperationResponse`
- Simplify `process-activation-requests` use case
    - Now we are going to handle any states when processing the activation requests
- Simplify `process-subscription-requests` use case
    - Now we are going to create an activation request for every subscription request, regardless its `state`
- Create composite index on `activation` container

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to change the state of a subscription.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [ ] I have committed only changes relevant to the task.
- [ ] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
