### PR TITLE
[IOPLT-653, IOPLT-657] Use `state` property instead of `activated`

### DIFF
--- a/.changeset/proud-dolphins-bake.md
+++ b/.changeset/proud-dolphins-bake.md
@@ -2,4 +2,4 @@
 "functions-subscription": minor
 ---
 
-[IOPLT-653, IOPLT-657] Use `state` property instead of `activated`
+[IOPLT-653, IOPLT-657] Update logic to use `state` property instead of `activated`

--- a/.changeset/proud-dolphins-bake.md
+++ b/.changeset/proud-dolphins-bake.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": minor
+---
+
+[IOPLT-653, IOPLT-657] Use `state` property instead of `activated`

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-job.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-job.test.ts
@@ -8,6 +8,7 @@ import { makeActivationJobCosmosContainer } from '../activation-job';
 import { ItemNotFound } from '../../../../domain/errors';
 
 describe('makeActivationJobCosmosContainer', () => {
+  const containerName = 'aContainerName';
   describe('get', () => {
     it('should get the item', async () => {
       const mockDB = makeDatabaseMock();
@@ -19,7 +20,10 @@ describe('makeActivationJobCosmosContainer', () => {
 
       const { trialId: id } = anActivationJob;
 
-      const actual = await makeActivationJobCosmosContainer(testDB).get(id)();
+      const actual = await makeActivationJobCosmosContainer(
+        testDB,
+        containerName,
+      ).get(id)();
 
       expect(actual).toStrictEqual(E.right(O.some(anActivationJob)));
       expect(mockDB.container('').item).toBeCalledWith(id, id);
@@ -36,10 +40,10 @@ describe('makeActivationJobCosmosContainer', () => {
         .container('')
         .items.create.mockResolvedValueOnce({ body: anActivationJob });
 
-      const actual =
-        await makeActivationJobCosmosContainer(testDB).insert(
-          anActivationJob,
-        )();
+      const actual = await makeActivationJobCosmosContainer(
+        testDB,
+        containerName,
+      ).insert(anActivationJob)();
 
       expect(actual).toStrictEqual(E.right(anActivationJob));
       expect(mockDB.container('').items.create).toBeCalledWith({
@@ -59,10 +63,10 @@ describe('makeActivationJobCosmosContainer', () => {
       mockDB.container('').item.mockReturnValueOnce({ patch: patchMock });
       patchMock.mockResolvedValueOnce({ resource: anActivationJob });
 
-      const actual = await makeActivationJobCosmosContainer(testDB).update(
-        trialId,
-        update,
-      )();
+      const actual = await makeActivationJobCosmosContainer(
+        testDB,
+        containerName,
+      ).update(trialId, update)();
 
       expect(actual).toStrictEqual(E.right(anActivationJob));
       expect(mockDB.container('').item).toBeCalledWith(trialId, trialId);
@@ -88,10 +92,10 @@ describe('makeActivationJobCosmosContainer', () => {
       mockDB.container('').item.mockReturnValueOnce({ patch: patchMock });
       patchMock.mockRejectedValueOnce(error);
 
-      const actual = await makeActivationJobCosmosContainer(testDB).update(
-        trialId,
-        update,
-      )();
+      const actual = await makeActivationJobCosmosContainer(
+        testDB,
+        containerName,
+      ).update(trialId, update)();
 
       expect(actual).toStrictEqual(
         E.left(

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
@@ -35,8 +35,8 @@ const makeTestData = (length: number) => {
             operations: [
               {
                 op: 'replace',
-                path: '/activated',
-                value: true,
+                path: '/state',
+                value: 'ACTIVE',
               },
             ],
           },

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/__tests__/activation-request.test.ts
@@ -67,6 +67,7 @@ const makeTestData = (length: number) => {
 };
 
 describe('makeActivationRequestReaderWriter', () => {
+  const containerName = 'aContainerName';
   describe('insert', () => {
     it('should return the inserted item', async () => {
       const mockDB = makeDatabaseMock();
@@ -77,6 +78,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).insert(anInsertActivationRequest)();
 
       expect(actual).toStrictEqual(E.right(anActivationRequest));
@@ -94,6 +96,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).insert(anInsertActivationRequest)();
 
       expect(actual).toMatchObject(
@@ -113,6 +116,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).activate([])();
 
       expect(actual).toStrictEqual(E.right(result));
@@ -133,6 +137,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).activate(activationRequests)();
 
       expect(actual).toStrictEqual(E.right(result));
@@ -165,6 +170,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).activate(activationRequests)();
 
       expect(actual).toStrictEqual(E.right(result));
@@ -188,6 +194,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).activate(activationRequests)();
 
       expect(actual).toStrictEqual(E.left(error));
@@ -211,6 +218,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).activate(activationRequests)();
 
       expect(actual).toStrictEqual(E.right(result));
@@ -235,6 +243,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).list(anActivationJob.trialId, elementsToFetch)();
 
       expect(actual).toStrictEqual(E.right(activationRequests));
@@ -249,6 +258,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).list(anActivationJob.trialId, elementsToFetch)();
 
       expect(actual).toStrictEqual(E.right([]));
@@ -264,6 +274,7 @@ describe('makeActivationRequestReaderWriter', () => {
 
       const actual = await makeActivationRequestReaderWriter(
         mockDB as unknown as Database,
+        containerName,
       ).list(anActivationJob.trialId, elementsToFetch)();
 
       expect(actual).toStrictEqual(E.left(error));

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-job.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-job.ts
@@ -12,8 +12,9 @@ import { decodeFromItem } from './decode';
 
 export const makeActivationJobCosmosContainer = (
   db: Database,
+  containerName: string,
 ): ActivationJobReader & ActivationJobWriter => {
-  const container = db.container('activations');
+  const container = db.container(containerName);
   return {
     get: (id) =>
       pipe(

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
@@ -49,7 +49,7 @@ export const makeActivationRequestReaderWriter = (
             container.items
               .query({
                 query:
-                  'SELECT * FROM c WHERE c.trialId = @trialId AND c.type = "request" AND c.activated = false ORDER BY c.id ASC OFFSET 0 LIMIT @limit',
+                  'SELECT * FROM c WHERE c.trialId = @trialId AND c.type = "request" AND c.state = "SUBSCRIBED" ORDER BY c.id ASC OFFSET 0 LIMIT @limit',
                 parameters: [
                   {
                     name: '@trialId',
@@ -112,8 +112,8 @@ const makeBatchOperations =
           operations: [
             {
               op: PatchOperationType.replace,
-              path: `/activated`,
-              value: true,
+              path: `/state`,
+              value: 'ACTIVE',
             },
           ],
         },

--- a/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
+++ b/apps/functions-subscription/src/adapters/azure/cosmosdb/activation-request.ts
@@ -24,8 +24,9 @@ import { TrialId } from '../../../domain/trial';
 
 export const makeActivationRequestReaderWriter = (
   db: Database,
+  containerName: string,
 ): ActivationRequestReader & ActivationRequestWriter => {
-  const container = db.container('activations');
+  const container = db.container(containerName);
   return {
     insert: (insertActivationRequest) =>
       pipe(

--- a/apps/functions-subscription/src/domain/__tests__/data.ts
+++ b/apps/functions-subscription/src/domain/__tests__/data.ts
@@ -56,7 +56,7 @@ export const anInsertActivationRequest = {
   id: anActivationRequestId,
   userId: aUserId,
   trialId: aTrialId,
-  activated: false,
+  state: 'SUBSCRIBED' as const,
   type: 'request' as const,
 };
 export const anActivationRequest = {
@@ -65,7 +65,7 @@ export const anActivationRequest = {
 };
 export const anActivationRequestActivated = {
   ...anInsertActivationRequest,
-  activated: true,
+  state: 'ACTIVE' as const,
   _etag: 'anEtag',
 };
 

--- a/apps/functions-subscription/src/domain/activation-request.ts
+++ b/apps/functions-subscription/src/domain/activation-request.ts
@@ -3,7 +3,7 @@ import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
 import * as RTE from 'fp-ts/lib/ReaderTaskEither';
 import { NonEmptyString } from '@pagopa/ts-commons/lib/strings';
-import { UserIdCodec } from './subscription';
+import { SubscriptionState, UserIdCodec } from './subscription';
 import { Capabilities } from './capabilities';
 import { ItemAlreadyExists } from './errors';
 import { TrialId, TrialIdCodec } from './trial';
@@ -26,7 +26,7 @@ export const ActivationRequestCodec = t.strict({
   trialId: TrialIdCodec,
   userId: UserIdCodec,
   type: t.literal('request'),
-  activated: t.boolean,
+  state: SubscriptionState,
   _etag: t.string,
 });
 export type ActivationRequest = t.TypeOf<typeof ActivationRequestCodec>;
@@ -66,8 +66,8 @@ export interface ActivationRequestWriter {
 export const makeInsertActivationRequest = ({
   trialId,
   userId,
-  activated,
-}: Pick<ActivationRequest, 'trialId' | 'userId' | 'activated'>) =>
+  state,
+}: Pick<ActivationRequest, 'trialId' | 'userId' | 'state'>) =>
   pipe(
     RTE.ask<Pick<Capabilities, 'monotonicIdFn'>>(),
     RTE.map(({ monotonicIdFn }) => monotonicIdFn()),
@@ -77,7 +77,7 @@ export const makeInsertActivationRequest = ({
       trialId,
       userId,
       type: 'request' as const,
-      activated,
+      state,
     })),
   );
 

--- a/apps/functions-subscription/src/domain/subscription.ts
+++ b/apps/functions-subscription/src/domain/subscription.ts
@@ -36,6 +36,13 @@ export const UserIdCodec = t.brand(
 );
 export type UserId = t.TypeOf<typeof UserIdCodec>;
 
+export const SubscriptionState = t.keyof({
+  UNSUBSCRIBED: null,
+  SUBSCRIBED: null,
+  ACTIVE: null,
+  DISABLED: null,
+});
+
 // this codec is useful to minimize the code duplication,
 // it is used by SubscriptionCodec and SubscriptionHistoryCodec
 export const SubscriptionWithoutIdCodec = t.strict({
@@ -43,12 +50,7 @@ export const SubscriptionWithoutIdCodec = t.strict({
   trialId: TrialIdCodec,
   createdAt: IsoDateFromString,
   updatedAt: IsoDateFromString,
-  state: t.keyof({
-    UNSUBSCRIBED: null,
-    SUBSCRIBED: null,
-    ACTIVE: null,
-    DISABLED: null,
-  }),
+  state: SubscriptionState,
 });
 
 export const SubscriptionCodec = t.intersection([

--- a/apps/functions-subscription/src/main.ts
+++ b/apps/functions-subscription/src/main.ts
@@ -79,6 +79,7 @@ const subscriptionHistoryReaderWriter = makeSubscriptionHistoryCosmosContainer(
 
 const activationJobReaderWriter = makeActivationJobCosmosContainer(
   cosmosDB.database(config.cosmosdb.databaseName),
+  config.cosmosdb.containersNames.activations,
 );
 
 const subscriptionQueue = makeSubscriptionQueueEventHubProducer(
@@ -87,6 +88,7 @@ const subscriptionQueue = makeSubscriptionQueueEventHubProducer(
 
 const activationRequestReaderWriter = makeActivationRequestReaderWriter(
   cosmosDB.database(config.cosmosdb.databaseName),
+  config.cosmosdb.containersNames.activations,
 );
 
 const eventWriter = makeEventWriterServiceBus(

--- a/apps/functions-subscription/src/use-cases/__tests__/process-subscription-request.test.ts
+++ b/apps/functions-subscription/src/use-cases/__tests__/process-subscription-request.test.ts
@@ -59,7 +59,7 @@ describe('processSubscriptionRequest', () => {
       TE.right({ ...aSubscriptionHistory, state: 'ACTIVE' }),
     );
     mockEnv.activationRequestWriter.insert.mockReturnValueOnce(
-      TE.right({ ...anActivationRequest, activated: true }),
+      TE.right({ ...anActivationRequest, state: 'ACTIVE' }),
     );
     mockEnv.activationRequestWriter.activate.mockReturnValueOnce(
       TE.right('success'),
@@ -72,7 +72,7 @@ describe('processSubscriptionRequest', () => {
 
     expect(actual).toStrictEqual(E.right({ userId, trialId }));
     expect(mockEnv.activationRequestWriter.activate).toBeCalledWith([
-      { ...anActivationRequest, activated: true },
+      { ...anActivationRequest, state: 'ACTIVE' },
     ]);
   });
   it('should not call activate if the request is neither ACTIVE nor SUBSCRIBED', async () => {

--- a/apps/functions-subscription/src/use-cases/process-activation-request.ts
+++ b/apps/functions-subscription/src/use-cases/process-activation-request.ts
@@ -18,9 +18,9 @@ type Env = Pick<
 export const processActivationRequest = ({
   trialId,
   userId,
-  activated,
+  state,
 }: ActivationRequest) => {
-  if (activated)
+  if (state === 'ACTIVE')
     return pipe(
       RTE.ask<Env>(),
       RTE.apSW('subscriptionId', makeSubscriptionId(trialId, userId)),

--- a/apps/functions-subscription/src/use-cases/process-subscription-request.ts
+++ b/apps/functions-subscription/src/use-cases/process-subscription-request.ts
@@ -22,7 +22,7 @@ const recoverItemAlreadyExists =
   };
 
 const handleActivatedRequest = (request: ActivationRequest) =>
-  request.activated
+  request.state === 'ACTIVE'
     ? pipe(
         // This operation is required to keep the number of activated users up to date.
         // The assumption is that the activation job exists.
@@ -42,7 +42,7 @@ export const processSubscriptionRequest = (subscription: Subscription) =>
             makeInsertActivationRequest({
               trialId: subscription.trialId,
               userId: subscription.userId,
-              activated: subscription.state === 'ACTIVE',
+              state: subscription.state,
             }),
             RTE.flatMap(insertActivationRequest),
             RTE.flatMap(handleActivatedRequest),

--- a/infra/resources/modules/commons/dashboard.tf
+++ b/infra/resources/modules/commons/dashboard.tf
@@ -19,7 +19,7 @@ resource "azurerm_dashboard" "main" {
       cosmosdb_account : module.cosmosdb_account.id,
       db_name : module.cosmosdb_sql_database_trial.name,
       subscription_container_name : azurerm_cosmosdb_sql_container.subscription.name,
-      activations_container_name : azurerm_cosmosdb_sql_container.activations.name,
+      activations_container_name : azurerm_cosmosdb_sql_container.activation.name,
       api_service_plan : module.func_api.function_app.plan.id,
       consumers_service_plan : module.func_consumers.function_app.plan.id,
       servicebus_namespace : azurerm_servicebus_namespace.main.id,

--- a/infra/resources/modules/commons/eventhub.tf
+++ b/infra/resources/modules/commons/eventhub.tf
@@ -18,7 +18,7 @@ module "event_hub" {
   ]
 
   alerts_enabled = true
-  metric_alerts  = {
+  metric_alerts = {
     num_of_messages = {
       aggregation = "Total"
       metric_name = "IncomingMessages"

--- a/infra/resources/modules/commons/function_api.tf
+++ b/infra/resources/modules/commons/function_api.tf
@@ -35,7 +35,7 @@ locals {
 
     ACTIVATION_CONSUMER                 = "off"
     ACTIVATION_MAX_FETCH_SIZE           = "999"
-    ACTIVATIONS_COSMOSDB_CONTAINER_NAME = azurerm_cosmosdb_sql_container.activations.name
+    ACTIVATIONS_COSMOSDB_CONTAINER_NAME = azurerm_cosmosdb_sql_container.activation.name
 
     EVENTS_PRODUCER              = "off"
     EVENTS_SERVICEBUS_TOPIC_NAME = azurerm_servicebus_topic.events.name

--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -31,11 +31,11 @@ locals {
     SUBSCRIPTION_HISTORY_COSMOSDB_CONTAINER_NAME         = azurerm_cosmosdb_sql_container.subscription_history.name
     SubscriptionHistoryCosmosConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
-    SUBSCRIPTION_REQUEST_CONSUMER                                  = "on"
+    SUBSCRIPTION_REQUEST_CONSUMER                                  = "off"
     SUBSCRIPTION_REQUEST_EVENTHUB_NAME                             = local.subscription_request_eventhub_name
     SubscriptionRequestEventHubConnection__fullyQualifiedNamespace = "${module.event_hub.name}.servicebus.windows.net"
 
-    ACTIVATION_CONSUMER                                   = "on"
+    ACTIVATION_CONSUMER                                   = "off"
     ACTIVATION_MAX_FETCH_SIZE                             = "999"
     ACTIVATIONS_COSMOSDB_CONTAINER_NAME                   = azurerm_cosmosdb_sql_container.activations.name
     ActivationConsumerCosmosDBConnection__accountEndpoint = module.cosmosdb_account.endpoint

--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -37,7 +37,7 @@ locals {
 
     ACTIVATION_CONSUMER                                   = "off"
     ACTIVATION_MAX_FETCH_SIZE                             = "999"
-    ACTIVATIONS_COSMOSDB_CONTAINER_NAME                   = azurerm_cosmosdb_sql_container.activations.name
+    ACTIVATIONS_COSMOSDB_CONTAINER_NAME                   = azurerm_cosmosdb_sql_container.activation.name
     ActivationConsumerCosmosDBConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
     EVENTS_PRODUCER              = "on"

--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -31,7 +31,7 @@ locals {
     SUBSCRIPTION_HISTORY_COSMOSDB_CONTAINER_NAME         = azurerm_cosmosdb_sql_container.subscription_history.name
     SubscriptionHistoryCosmosConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
-    SUBSCRIPTION_REQUEST_CONSUMER                                  = "off"
+    SUBSCRIPTION_REQUEST_CONSUMER                                  = "on"
     SUBSCRIPTION_REQUEST_EVENTHUB_NAME                             = local.subscription_request_eventhub_name
     SubscriptionRequestEventHubConnection__fullyQualifiedNamespace = "${module.event_hub.name}.servicebus.windows.net"
 


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->
Depends on #161 #163

#### List of Changes
<!--- Describe your changes in detail -->
- Turn off activation consumer
- Remove `activated` property from ActivationRequest
- Add `state` property to ActivationRequest
- Update environment variable to use the new name of `activation` container

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to be more flexible when handling the activation request.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [ ] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
