### PR TITLE
[IOPLT-664] Remove metric about memory from consumer func

### DIFF
--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -236,8 +236,8 @@ module "function_consumptions_autoscaler" {
 
   scheduler = {
     normal_load = {
-      default = 1
-      minimum = 1
+      default = 3
+      minimum = 3
     }
     maximum = 30
   }

--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -252,7 +252,8 @@ module "function_consumptions_autoscaler" {
       statistic_decrease        = "Max"
       time_aggregation_increase = "Maximum"
       time_aggregation_decrease = "Maximum"
-    }
+    },
+    memory = null
   }
 
   tags = var.tags

--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -236,8 +236,8 @@ module "function_consumptions_autoscaler" {
 
   scheduler = {
     normal_load = {
-      default = 3
-      minimum = 3
+      default = 1
+      minimum = 1
     }
     maximum = 30
   }


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Remove autoscaling rule based on memory of consumer function
- Change the normal load of consumer function

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Memory is not a metric to consider for autoscaling the consumer function. The consumer function processes jobs asynchronously, so it can have at least one instance.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
N/A

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
