### PR TITLE
[IOPLT-605] Enforce config type

### DIFF
--- a/.changeset/small-windows-smoke.md
+++ b/.changeset/small-windows-smoke.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": patch
+---
+
+Add missing environment variables

--- a/.changeset/strange-peas-poke.md
+++ b/.changeset/strange-peas-poke.md
@@ -1,0 +1,5 @@
+---
+"functions-subscription": minor
+---
+
+Decode CosmosConnection variables; if the variables are missing, there will be a runtime error on startup.

--- a/apps/functions-subscription/local.settings.json.example
+++ b/apps/functions-subscription/local.settings.json.example
@@ -23,21 +23,20 @@
 
     "SUBSCRIPTION_REQUEST_CONSUMER": "on",
     "SUBSCRIPTION_REQUEST_EVENTHUB_NAME": "<put-here-the-name-of-the-event-hub>",
+    "SubscriptionRequestEventHubConnection__fullyQualifiedNamespace": "<put-here-the-the-event-hub-fully-qualified-namespace>",
 
     "EVENTS_PRODUCER": "on",
     "EVENTS_SERVICEBUS_TOPIC_NAME": "<put-here-the-the-service-bus-topic-name>",
-    "EventProducerCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
-    "EventProducerCosmosConnection": "<put-here-the-the-cosmos-database-connection-string>",
 
     "ACTIVATION_CONSUMER": "on",
     "ACTIVATIONS_COSMOSDB_CONTAINER_NAME": "activations",
     "ACTIVATION_MAX_FETCH_SIZE": "50",
-    "ActivationConsumerCosmosDBConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
     "ActivationConsumerCosmosDBConnection": "<put-here-the-the-cosmos-database-connection-string>",
+    "ActivationConsumerCosmosDBConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
 
     "TRIAL_CONSUMER": "off",
     "TRIALS_COSMOSDB_CONTAINER_NAME": "trials",
-    "TrialsCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
-    "TrialsCosmosConnection": "<put-here-the-the-cosmos-database-connection-string>"
+    "TrialsCosmosConnection": "<put-here-the-the-cosmos-database-connection-string>",
+    "TrialsCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>"
   }
 }

--- a/apps/functions-subscription/local.settings.json.example
+++ b/apps/functions-subscription/local.settings.json.example
@@ -17,6 +17,8 @@
 
     "SUBSCRIPTION_HISTORY_CONSUMER": "on",
     "SUBSCRIPTION_HISTORY_COSMOSDB_CONTAINER_NAME": "subscription-history",
+    # On local development, prefer the connection string instead of the account endpoint
+    "SubscriptionHistoryCosmosConnection": "<put-here-the-the-cosmos-database-connection-string>",
     "SubscriptionHistoryCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
 
     "SUBSCRIPTION_REQUEST_CONSUMER": "on",
@@ -25,14 +27,17 @@
     "EVENTS_PRODUCER": "on",
     "EVENTS_SERVICEBUS_TOPIC_NAME": "<put-here-the-the-service-bus-topic-name>",
     "EventProducerCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
+    "EventProducerCosmosConnection": "<put-here-the-the-cosmos-database-connection-string>",
 
     "ACTIVATION_CONSUMER": "on",
     "ACTIVATIONS_COSMOSDB_CONTAINER_NAME": "activations",
     "ACTIVATION_MAX_FETCH_SIZE": "50",
     "ActivationConsumerCosmosDBConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
+    "ActivationConsumerCosmosDBConnection": "<put-here-the-the-cosmos-database-connection-string>",
 
     "TRIAL_CONSUMER": "off",
     "TRIALS_COSMOSDB_CONTAINER_NAME": "trials",
-    "TrialsCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>"
+    "TrialsCosmosConnection__accountEndpoint": "<put-here-the-the-cosmos-database-account-endpoint>",
+    "TrialsCosmosConnection": "<put-here-the-the-cosmos-database-connection-string>"
   }
 }

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/process-activations-changes.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/process-activations-changes.test.ts
@@ -9,7 +9,13 @@ import * as O from 'fp-ts/Option';
 import * as TE from 'fp-ts/TaskEither';
 import { makeActivationsChangesHandler } from '../process-activations-changes';
 
-const config = { activations: { consumer: 'on' as const, maxFetchSize: 1 } };
+const config = {
+  activations: {
+    consumer: 'on' as const,
+    maxFetchSize: 1,
+    connectionString: 'aConnectionString',
+  },
+};
 
 describe('makeActivationJobConsumerHandler', () => {
   it('should call processActivationJob as expected', async () => {

--- a/apps/functions-subscription/src/config.ts
+++ b/apps/functions-subscription/src/config.ts
@@ -83,14 +83,11 @@ const EnvsCodec = t.type({
   SUBSCRIPTION_ID: NonEmptyString,
   SERVICE_BUS_RESOURCE_GROUP_NAME: NonEmptyString,
   SERVICE_BUS_LOCATION: NonEmptyString,
-  SubscriptionHistoryCosmosConnection: t.union([NonEmptyString, t.undefined]),
-  SubscriptionHistoryCosmosConnection__accountName: NonEmptyString,
-  ActivationConsumerCosmosDBConnection: t.union([NonEmptyString, t.undefined]),
   ActivationConsumerCosmosDBConnection__accountEndpoint: NonEmptyString,
-  SubscriptionRequestEventHubConnection: t.union([NonEmptyString, t.undefined]),
-  SubscriptionRequestEventHubConnection__accountName: NonEmptyString,
-  TrialsCosmosConnection: t.union([NonEmptyString, t.undefined]),
+  SubscriptionHistoryCosmosConnection__accountEndpoint: NonEmptyString,
   TrialsCosmosConnection__accountEndpoint: NonEmptyString,
+  SubscriptionRequestEventHubConnection__fullyQualifiedNamespace:
+    NonEmptyString,
 });
 
 export const parseConfig = (

--- a/apps/functions-subscription/src/config.ts
+++ b/apps/functions-subscription/src/config.ts
@@ -10,15 +10,6 @@ import {
 
 type OnOrOff = 'on' | 'off';
 
-interface ActiveConsumer {
-  readonly consumer: Extract<OnOrOff, 'on'>;
-  readonly connectionString: string;
-}
-interface InactiveConsumer {
-  readonly consumer: Extract<OnOrOff, 'off'>;
-}
-type Consumer = ActiveConsumer | InactiveConsumer;
-
 const OnOrOffCodec = t.keyof<{
   readonly [K in OnOrOff]: unknown;
 }>({
@@ -27,13 +18,22 @@ const OnOrOffCodec = t.keyof<{
 });
 
 export interface Config {
-  readonly subscriptionHistory: Consumer;
-  readonly subscriptionRequest: Consumer;
-  readonly activations: Consumer & { readonly maxFetchSize: number };
+  readonly subscriptionHistory: {
+    readonly consumer: OnOrOff;
+  };
+  readonly subscriptionRequest: {
+    readonly consumer: OnOrOff;
+  };
+  readonly activations: {
+    readonly consumer: OnOrOff;
+    readonly maxFetchSize: number;
+  };
   readonly events: {
     readonly producer: OnOrOff;
   };
-  readonly trials: Consumer;
+  readonly trials: {
+    readonly consumer: OnOrOff;
+  };
   readonly servicebus: {
     readonly namespace: string;
     readonly names: {
@@ -103,21 +103,12 @@ export const parseConfig = (
       (envs) => ({
         subscriptionHistory: {
           consumer: envs.SUBSCRIPTION_HISTORY_CONSUMER,
-          connectionString:
-            envs.SubscriptionHistoryCosmosConnection ||
-            envs.SubscriptionHistoryCosmosConnection__accountName,
         },
         subscriptionRequest: {
           consumer: envs.SUBSCRIPTION_REQUEST_CONSUMER,
-          connectionString:
-            envs.SubscriptionRequestEventHubConnection ||
-            envs.SubscriptionRequestEventHubConnection__accountName,
         },
         activations: {
           consumer: envs.ACTIVATION_CONSUMER,
-          connectionString:
-            envs.ActivationConsumerCosmosDBConnection ||
-            envs.ActivationConsumerCosmosDBConnection__accountEndpoint,
           maxFetchSize: envs.ACTIVATION_MAX_FETCH_SIZE,
         },
         events: {
@@ -125,9 +116,6 @@ export const parseConfig = (
         },
         trials: {
           consumer: envs.TRIAL_CONSUMER,
-          connectionString:
-            envs.TrialsCosmosConnection ||
-            envs.TrialsCosmosConnection__accountEndpoint,
         },
         servicebus: {
           namespace: envs.SERVICEBUS_NAMESPACE,

--- a/infra/resources/modules/commons/function_api.tf
+++ b/infra/resources/modules/commons/function_api.tf
@@ -27,21 +27,25 @@ locals {
 
     LEASES_COSMOSDB_CONTAINER_NAME = azurerm_cosmosdb_sql_container.leases.name
 
-    SUBSCRIPTION_HISTORY_CONSUMER                = "off"
-    SUBSCRIPTION_HISTORY_COSMOSDB_CONTAINER_NAME = azurerm_cosmosdb_sql_container.subscription_history.name
+    SUBSCRIPTION_HISTORY_CONSUMER                        = "off"
+    SUBSCRIPTION_HISTORY_COSMOSDB_CONTAINER_NAME         = azurerm_cosmosdb_sql_container.subscription_history.name
+    SubscriptionHistoryCosmosConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
-    SUBSCRIPTION_REQUEST_CONSUMER      = "off"
-    SUBSCRIPTION_REQUEST_EVENTHUB_NAME = local.subscription_request_eventhub_name
+    SUBSCRIPTION_REQUEST_CONSUMER                                  = "off"
+    SUBSCRIPTION_REQUEST_EVENTHUB_NAME                             = local.subscription_request_eventhub_name
+    SubscriptionRequestEventHubConnection__fullyQualifiedNamespace = "${module.event_hub.name}.servicebus.windows.net"
 
-    ACTIVATION_CONSUMER                 = "off"
-    ACTIVATION_MAX_FETCH_SIZE           = "999"
-    ACTIVATIONS_COSMOSDB_CONTAINER_NAME = azurerm_cosmosdb_sql_container.activation.name
+    ACTIVATION_CONSUMER                                   = "off"
+    ACTIVATION_MAX_FETCH_SIZE                             = "999"
+    ACTIVATIONS_COSMOSDB_CONTAINER_NAME                   = azurerm_cosmosdb_sql_container.activation.name
+    ActivationConsumerCosmosDBConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
     EVENTS_PRODUCER              = "off"
     EVENTS_SERVICEBUS_TOPIC_NAME = azurerm_servicebus_topic.events.name
 
-    TRIAL_CONSUMER                 = "off"
-    TRIALS_COSMOSDB_CONTAINER_NAME = azurerm_cosmosdb_sql_container.trials.name
+    TRIAL_CONSUMER                          = "off"
+    TRIALS_COSMOSDB_CONTAINER_NAME          = azurerm_cosmosdb_sql_container.trials.name
+    TrialsCosmosConnection__accountEndpoint = module.cosmosdb_account.endpoint
   }
 }
 


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

> [!NOTE]
> This is an alternative solution to fix a problem.
> [An issue has been opened to ask for help](https://github.com/Azure/azure-functions-nodejs-library/issues/299), but in the meantime we are reducing the human error enforcing the configuration type.

#### List of Changes
<!--- Describe your changes in detail -->
- Add the `*__accountEndpoint` variables to the config type
    - In this way we are enforcing the application to give an error if some configuration parameter is missing
- Improve type of `OnOffCodec`
- Add new environment variables to the `api` function

> [!IMPORTANT]
> On local development, it easier to use the connections string instead of the Azure Identity method to authenticate to the services.
>
> It is recommended then to fill the `*CosmosConnection` parameter as well (the result is there is a `*CosmosConnection` and a `*CosmosConnection__accountEndpoint` variable populated).
> Azure documentation says: "If the configured value is both an exact match for a single setting and a prefix match for other settings, the exact match is used.".

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
