### PR TITLE
[IOPLT-700] Update middleware that checks `x-user-groups` header

### DIFF
--- a/.changeset/grumpy-carrots-hunt.md
+++ b/.changeset/grumpy-carrots-hunt.md
@@ -1,0 +1,6 @@
+---
+"functions-subscription": minor
+---
+
+[IOPLT-700] Update logic of middleware that checks `x-user-groups` header.
+Now the allowed values for the `x-user-groups` are: `ApiTrialManager` and `ApiTrialUser`.

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-subscription.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/get-subscription.test.ts
@@ -79,4 +79,29 @@ describe('makeGetSubscriptionHandler', () => {
       state: aSubscription.state,
     });
   });
+
+  it('should return 200 when the subscription exist and the x-user-groups header has ApiTrialUser', async () => {
+    const env = makeTestSystemEnv();
+
+    env.getSubscription.mockReturnValueOnce(TE.right(aSubscription));
+
+    const request = new HttpRequest({
+      url: makeAValidGetSubscriptionRequest().url,
+      params: makeAValidGetSubscriptionRequest().params,
+      method: makeAValidGetSubscriptionRequest().method,
+      headers: { 'x-user-groups': 'ApiTrialUser' },
+    });
+
+    const actual = await makeGetSubscriptionHandler(env)(
+      request,
+      makeFunctionContext(),
+    );
+
+    expect(actual.status).toStrictEqual(200);
+    expect(await actual.json()).toMatchObject({
+      userId: aSubscription.userId,
+      trialId: aSubscription.trialId,
+      state: aSubscription.state,
+    });
+  });
 });

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
@@ -35,16 +35,16 @@ describe('parseRequestBody', () => {
 });
 
 describe('verifyUserGroup', () => {
-  it('should return Left if the `x-user-groups` header does not contain the given group', async () => {
+  it('should return Left if the `x-user-groups` header does not contain any of the given groups', async () => {
     const req: H.HttpRequest = {
       ...aValidRequest,
       headers: {
         'x-user-groups': 'aGroup,anAnotherGroup',
       },
     };
-    const actual = verifyUserGroup('ApiTrialManager')(req);
+    const actual = verifyUserGroup(['ApiTrialManager', 'ApiTrialUser'])(req);
     const expected = new H.HttpForbiddenError(
-      `Missing required group: ApiTrialManager`,
+      `Missing required group: ApiTrialManager,ApiTrialUser`,
     );
     expect(actual).toStrictEqual(E.left(expected));
   });
@@ -53,7 +53,7 @@ describe('verifyUserGroup', () => {
     const req: H.HttpRequest = {
       ...aValidRequest,
     };
-    const actual = verifyUserGroup('ApiTrialManager')(req);
+    const actual = verifyUserGroup(['ApiTrialManager', 'ApiTrialUser'])(req);
     expect(actual).toStrictEqual(E.right(void 0));
   });
 
@@ -64,7 +64,7 @@ describe('verifyUserGroup', () => {
         'x-user-groups': 'aGroup,ApiTrialManager,anAnotherGroup',
       },
     };
-    const actual = verifyUserGroup('ApiTrialManager')(req);
+    const actual = verifyUserGroup(['ApiTrialManager', 'ApiTrialUser'])(req);
     expect(actual).toStrictEqual(E.right(void 0));
   });
 });

--- a/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/__tests__/middleware.test.ts
@@ -39,12 +39,12 @@ describe('verifyUserGroup', () => {
     const req: H.HttpRequest = {
       ...aValidRequest,
       headers: {
-        'x-user-groups': 'aGroup,anAnotherGroup',
+        'x-user-groups': 'ApiTrial,anAnotherGroup,ApiTrialUser',
       },
     };
-    const actual = verifyUserGroup(['ApiTrialManager', 'ApiTrialUser'])(req);
+    const actual = verifyUserGroup(['ApiTrialManager'])(req);
     const expected = new H.HttpForbiddenError(
-      `Missing required group: ApiTrialManager,ApiTrialUser`,
+      `Missing required group: ApiTrialManager`,
     );
     expect(actual).toStrictEqual(E.left(expected));
   });

--- a/apps/functions-subscription/src/adapters/azure/functions/create-trial.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/create-trial.ts
@@ -19,7 +19,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Env>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup(['ApiTrialManager'])(req))),
     RTE.apSW('requestBody', RTE.fromEither(parseRequestBody(CreateTrial)(req))),
     RTE.flatMapTaskEither(
       ({ requestBody: { name, description }, createTrial }) =>

--- a/apps/functions-subscription/src/adapters/azure/functions/get-activation-job.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/get-activation-job.ts
@@ -20,7 +20,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Env>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup(['ApiTrialManager'])(req))),
     RTE.apSW(
       'trialId',
       RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/get-subscription.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/get-subscription.ts
@@ -18,7 +18,9 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) => {
   return pipe(
     RTE.ask<Pick<SystemEnv, 'getSubscription'>>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(
+      RTE.fromEither(verifyUserGroup(['ApiTrialManager', 'ApiTrialUser'])(req)),
+    ),
     RTE.apSW(
       'userId',
       RTE.fromEither(parsePathParameter(UserIdCodec, 'userId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/get-trial.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/get-trial.ts
@@ -20,7 +20,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Env>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup(['ApiTrialManager'])(req))),
     RTE.apSW(
       'trialId',
       RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/insert-subscription.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/insert-subscription.ts
@@ -25,7 +25,9 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) => {
   return pipe(
     RTE.ask<Pick<SystemEnv, 'createSubscription'>>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(
+      RTE.fromEither(verifyUserGroup(['ApiTrialManager', 'ApiTrialUser'])(req)),
+    ),
     RTE.apSW(
       'requestBody',
       RTE.fromEither(parseRequestBody(CreateSubscription)(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
@@ -45,7 +45,7 @@ export const verifyUserGroup =
       req.headers['x-user-groups'],
       E.fromNullable(void 0),
       E.foldW(
-        // if x-user-groups does not exists behave like it were included
+        // if x-user-groups does not exist behave like it were included
         E.right,
         // if exists then verify if it is included
         flow(

--- a/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/middleware.ts
@@ -54,8 +54,8 @@ export const verifyUserGroup =
           E.map((stringGroups) => stringGroups.split(',')),
           E.filterOrElseW(
             (headerGroups) =>
-              headerGroups.some((group) =>
-                allowedGroups.toString().includes(group),
+              allowedGroups.some((allowedGroup) =>
+                headerGroups.includes(allowedGroup),
               ),
             () =>
               new H.HttpForbiddenError(

--- a/apps/functions-subscription/src/adapters/azure/functions/update-activation-job.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/update-activation-job.ts
@@ -23,7 +23,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) =>
   pipe(
     RTE.ask<Pick<SystemEnv, 'updateActivationJob'>>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup(['ApiTrialManager'])(req))),
     RTE.apSW(
       'trialId',
       RTE.fromEither(parsePathParameter(TrialIdCodec, 'trialId')(req)),

--- a/apps/functions-subscription/src/adapters/azure/functions/update-subscription.ts
+++ b/apps/functions-subscription/src/adapters/azure/functions/update-subscription.ts
@@ -23,7 +23,7 @@ const makeHandlerKitHandler: H.Handler<
 > = H.of((req: H.HttpRequest) => {
   return pipe(
     RTE.ask<Pick<SystemEnv, 'updateSubscription'>>(),
-    RTE.apFirst(RTE.fromEither(verifyUserGroup('ApiTrialManager')(req))),
+    RTE.apFirst(RTE.fromEither(verifyUserGroup(['ApiTrialManager'])(req))),
     RTE.apSW(
       'userId',
       RTE.fromEither(parsePathParameter(UserIdCodec, 'userId')(req)),


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Check if at least one of the allowed user groups is present in the `x-user-groups` header
    - This PR depends on #192 which add the new group
- Authorize `ApiTrialUser` to the `GET /trials/{trialId}/subscriptions/{userId}` and `POST /trials/{trialId}/subscriptions`
- Create a new `AllowedGroup` type which helps the developer to insert only a predefined set of values

> [!IMPORTANT]
> The backward compatibility is granted.
> If any HTTP calls are coming to the Azure functions, so the `x-user-groups` header is not filled, then the Azure function does not change its behaviour.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
IO Backend is going to use an APIM subscription related to a new user group.
We need to authorize the calls coming from that subscriptions.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
