### PR TITLE
[IOPLT-702] Do not use the default Git user

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
           # https://github.com/actions/checkout/issues/1471#issuecomment-1771231294
           fetch-tags: true
           fetch-depth: 0
+          token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Setup Node.js environment
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,5 +40,6 @@ jobs:
           version: yarn run version
           publish: yarn run release
           commit: 'ci(changesets): version packages'
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Use a different token when checking out the code
- Override `setupGitUser` value to not use the default Git user when performing `git` operations

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When closing the PR created by changeset, the expected behaviour is that a deploy workflow starts.
This is not happening right now, and it looks like that changeset uses the default Git user to perform operations (even though a different token has been set as `GITHUB_TOKEN`).

In a [discussion on an issue](https://github.com/changesets/action/issues/187#issuecomment-1228413850), it looks like that also during the checkout we should use the token that is going to use changeset.
We also need to instruct changeset not to use the default Git account.


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my code.
- [ ] I have committed only changes relevant to the task.
- [ ] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
