### PR TITLE
Do not execute code review on infra code when changelog changed

### DIFF
--- a/.github/workflows/code_review_infra.yaml
+++ b/.github/workflows/code_review_infra.yaml
@@ -14,6 +14,9 @@ on:
       # Trigger the workflow when the involved workflows are modified
       - ".github/workflows/code_review_infra.yaml"
       - ".github/workflows/templates/infra_**"
+      # Do not trigger the workflow when the next files are modified
+      - "!infra/resources/package.json"
+      - "!infra/resources/CHANGELOG.md"
 
 jobs:
   code_review_prod:


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Exclude `package.json` and `CHANGELOG.md` file on workflow

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We do not want to execute any Terraform related operation on PR opened by changeset, like what happened in [this PR](https://github.com/pagopa/trial-system/pull/200).

> [!NOTE]
> The order of `paths` patterns matters.
> A matching negative pattern (prefixed with !) after a positive match will exclude the path. [ref](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my code.
- [ ] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [ ] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
