### PR TITLE
Revert "[IOPLT-741] Update value of `TRIALS_COSMOSDB_CONTAINER_NAME` environment variable"

### DIFF
--- a/.changeset/happy-tips-drop.md
+++ b/.changeset/happy-tips-drop.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": patch
+---
+
+Revert "[IOPLT-741] Update value of `TRIALS_COSMOSDB_CONTAINER_NAME` environment variable"

--- a/infra/resources/modules/commons/function_api.tf
+++ b/infra/resources/modules/commons/function_api.tf
@@ -46,7 +46,7 @@ locals {
     EVENTS_SERVICEBUS_TOPIC_NAME = azurerm_servicebus_topic.events.name
 
     TRIAL_CONSUMER                          = "off"
-    TRIALS_COSMOSDB_CONTAINER_NAME          = azurerm_cosmosdb_sql_container.trial.name
+    TRIALS_COSMOSDB_CONTAINER_NAME          = azurerm_cosmosdb_sql_container.trials.name
     TrialsCosmosConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
     AI_CONNECTION_STRING = azurerm_application_insights.ai.connection_string

--- a/infra/resources/modules/commons/function_consumptions.tf
+++ b/infra/resources/modules/commons/function_consumptions.tf
@@ -46,7 +46,7 @@ locals {
     EVENTS_SERVICEBUS_TOPIC_NAME = azurerm_servicebus_topic.events.name
 
     TRIAL_CONSUMER                          = "on"
-    TRIALS_COSMOSDB_CONTAINER_NAME          = azurerm_cosmosdb_sql_container.trial.name
+    TRIALS_COSMOSDB_CONTAINER_NAME          = azurerm_cosmosdb_sql_container.trials.name
     TrialsCosmosConnection__accountEndpoint = module.cosmosdb_account.endpoint
 
     AI_CONNECTION_STRING = azurerm_application_insights.ai.connection_string


### PR DESCRIPTION
Reverts pagopa/trial-system#232

> [!IMPORTANT]
> Since the `trial` container has a different partition key, we also have to change the query to get a single item (which is a point read). We need to revert this PR and make a new one, thinking how to do the operation without causing some disservice.